### PR TITLE
feat/docs: Core backend logic for reply messaging system

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -59,6 +59,7 @@
       "version": "7.29.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1046,9 +1047,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1063,9 +1061,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1080,9 +1075,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1097,9 +1089,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1114,9 +1103,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1131,9 +1117,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1148,9 +1131,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1165,9 +1145,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1182,9 +1159,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1199,9 +1173,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1216,9 +1187,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1231,9 +1199,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1246,9 +1211,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1560,9 +1522,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1580,9 +1539,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1598,9 +1554,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1616,9 +1569,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1765,6 +1715,7 @@
       "version": "19.2.14",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1809,6 +1760,7 @@
       "version": "8.15.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1898,6 +1850,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2118,6 +2071,7 @@
       "version": "9.39.2",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2709,9 +2663,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2733,9 +2684,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2755,9 +2703,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2777,9 +2722,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2993,6 +2935,7 @@
       "version": "4.0.4",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3039,6 +2982,7 @@
       "version": "3.8.3",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -3143,6 +3087,7 @@
     "node_modules/react": {
       "version": "19.2.5",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3150,6 +3095,7 @@
     "node_modules/react-dom": {
       "version": "19.2.5",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -3162,6 +3108,7 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.72.1.tgz",
       "integrity": "sha512-RhwBoy2ygeVZje+C+bwJ8g0NjTdBmDlJvAUHTxRjTmSUKPYsKfMphkS2sgEMotsY03bP358yEYlnUeZy//D9Ig==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -3462,6 +3409,7 @@
       "version": "7.3.2",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -3606,6 +3554,7 @@
       "version": "4.3.6",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -298,6 +298,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
       "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }

--- a/server/controllers/repliesController.js
+++ b/server/controllers/repliesController.js
@@ -1,15 +1,24 @@
 const replyService = require('../services/replyService');
 
+// Regex to validate UUID format
+function isValidUUID(uuid) {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(uuid);
+}
+
 /**
  * Controller for fetching all replies for a post.
  * Responds with a placeholder message for now.
  */
 exports.getRepliesForPost = async (req, res) => {
+    const postId = req.params.postId;
+    if (!isValidUUID(postId)) {
+        return res.status(400).json({ message: 'Invalid postId format (must be UUID)' });
+    }
     try {
-        // Call the service function (not implemented yet)
-        const replies = await replyService.getRepliesForPost(req.params.postId);
+        const replies = await replyService.getRepliesForPost(postId);
         res.status(200).json({ replies });
     } catch (err) {
+        console.error('Error fetching replies:', err);
         res.status(500).json({ message: 'Error(500):Internal server error' });
     }
 };

--- a/server/controllers/repliesController.js
+++ b/server/controllers/repliesController.js
@@ -6,6 +6,18 @@ function isValidUUID(uuid) {
 }
 
 /**
+ * POST /api/posts/:postId/replies
+ * 
+ * 
+ * Controller for creating a top-level reply to a post.
+ */
+exports.createTopLevelReply = async (req, res) => {
+  res.status(501).json({ message: 'Not implemented: create top-level reply' });
+};
+
+/**
+ * GET /api/posts/:postId/replies
+ * 
  * Controller for fetching all replies for a post.
  * Responds with a placeholder message for now.
  */

--- a/server/controllers/repliesController.js
+++ b/server/controllers/repliesController.js
@@ -19,30 +19,52 @@ exports.createTopLevelReply = async (req, res) => {
     if (!isValidUUID(postId)) {
         return res.status(400).json({ message: 'Invalid postId format (must be UUID)' });
     }
-
     // Validate content of reply after trimming it
     if (!content || typeof content !== 'string' || content.trim().length === 0) {
         return res.status(400).json({ message: 'Content is required and cannot be empty.' });
     }
-
     // Enforce a maximum length for the content
     if (content.length > 1000) {
         return res.status(400).json({ message: 'Content must be under 1000 characters.' });
     }
 
-    // Check if post exists
+    // Auth logic
+    const authHeader = req.headers.authorization;
+    if (!authHeader) {
+        return res.status(401).json({ message: "No auth token" });
+    }
+    const [scheme, token] = authHeader.split(" ");
+    if (scheme !== "Bearer" || !token) {
+        return res.status(401).json({ message: "Invalid authorization format" });
+    }
+    const { data, error } = await supabase.auth.getUser(token);
+    if (error || !data.user) {
+        return res.status(401).json({ message: "Invalid token" });
+    }
+    const auth_user_id = data.user.id;
+
+    // For now, use a placeholder user object if skipping real user lookup
+    const user = {
+        id: auth_user_id, // Replace with real user id when ready
+        username: "TestUser", // Replace with real username from DB
+        language: "English"   // Replace with real language from DB
+    };
+
     try {
         const postExists = await replyService.checkPostExists(postId);
         if (!postExists) {
             return res.status(404).json({ message: 'Post not found.' });
         }
-        res.status(501).json({ message: 'Not implemented: post existence check done' });
+
+        // Call the service to insert the reply
+        const reply = await replyService.createTopLevelReply(postId, user, content);
+
+        // Respond with the created reply
+        res.status(201).json(reply);
     } catch (err) {
-        console.error('Error checking post existence:', err);
+        console.error('Error creating reply:', err);
         res.status(500).json({ message: 'Internal server error' });
     }
-
-    res.status(501).json({ message: 'Not implemented: create top-level reply (validation done)' });
 };
 
 /**

--- a/server/controllers/repliesController.js
+++ b/server/controllers/repliesController.js
@@ -6,7 +6,7 @@ function isValidUUID(uuid) {
 }
 
 /**
- * POST /api/posts/:postId/replies
+ * Related: POST /api/posts/:postId/replies
  * 
  * Controller for creating a top-level reply to a post.
  */
@@ -67,7 +67,7 @@ exports.createTopLevelReply = async (req, res) => {
 };
 
 /**
- * POST /api/replies/:replyId/replies
+ * Related: POST /api/replies/:replyId/replies
  * 
  * Controller for creating a nested reply to an existing reply.
  */
@@ -116,7 +116,7 @@ exports.createNestedReply = async (req, res) => {
 };
 
 /**
- * GET /api/posts/:postId/replies
+ * Related: GET /api/posts/:postId/replies
  * 
  * Controller for fetching all replies for a post.
  * Responds with a placeholder message for now.

--- a/server/controllers/repliesController.js
+++ b/server/controllers/repliesController.js
@@ -12,7 +12,25 @@ function isValidUUID(uuid) {
  * Controller for creating a top-level reply to a post.
  */
 exports.createTopLevelReply = async (req, res) => {
-  res.status(501).json({ message: 'Not implemented: create top-level reply' });
+    const postId = req.params.postId;
+    const { content } = req.body;
+
+    // Validate postId is in UUID format
+    if (!isValidUUID(postId)) {
+        return res.status(400).json({ message: 'Invalid postId format (must be UUID)' });
+    }
+
+    // Validate content of reply after trimming it
+    if (!content || typeof content !== 'string' || content.trim().length === 0) {
+        return res.status(400).json({ message: 'Content is required and cannot be empty.' });
+    }
+
+    // Enforce a maximum length for the content
+    if (content.length > 1000) {
+        return res.status(400).json({ message: 'Content must be under 1000 characters.' });
+    }
+
+    res.status(501).json({ message: 'Not implemented: create top-level reply (validation done)' });
 };
 
 /**

--- a/server/controllers/repliesController.js
+++ b/server/controllers/repliesController.js
@@ -1,35 +1,71 @@
+/**
+ * -----------------------------------------------------------------------------
+ * Replies Controller
+ * -----------------------------------------------------------------------------
+ * Purpose:
+ *   Handles HTTP request/response flow for replies endpoints.
+ *
+ * How this file connects to others:
+ *   - Called by routes/replies.js
+ *   - Uses services/replyService.js for database/business operations
+ *   - Uses supabase.auth.getUser(token) to resolve authenticated users
+ *
+ * Responsibilities:
+ *   - Parse and validate request inputs (params, query, body)
+ *   - Enforce API-level error responses and status codes
+ *   - Delegate persistence/business logic to the service layer
+ * -----------------------------------------------------------------------------
+ */
+
 const supabase = require('../supabaseClient');
 const replyService = require('../services/replyService');
 
-// Regex to validate UUID format
+/**
+ * Validate UUID format for route params.
+ *
+ * @param {string} uuid
+ * @returns {boolean}
+ */
 function isValidUUID(uuid) {
   return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(uuid);
 }
 
 /**
- * Related: POST /api/posts/:postId/replies
- * 
- * Controller for creating a top-level reply to a post.
+ * POST /api/posts/:postId/replies
+ *
+ * Creates a top-level reply for a given post.
+ *
+ * Flow:
+ *   1) Validate route params and content
+ *   2) Resolve authenticated user from Bearer token
+ *   3) Load user profile (anonymous_name + language)
+ *   4) Confirm post exists
+ *   5) Delegate insert to service layer
+ *
+ * Returns:
+ *   201 with public reply shape on success
+ *   400/401/404 for expected validation/auth/not-found failures
+ *   500 for unexpected server errors
  */
 exports.createTopLevelReply = async (req, res) => {
     const postId = req.params.postId;
     const { content } = req.body || {};
 
-    // 400: Validate postId is in UUID format
+    // 400: Invalid route param
     if (!isValidUUID(postId)) {
         return res.status(400).json({ message: 'Invalid field: postId (must be UUID)' });
     }
-    // 400: Validate content of reply after trimming it
+    // 400: Invalid or missing content
     if (!content || typeof content !== 'string' || content.trim().length === 0) {
         return res.status(400).json({ message: 'Invalid field: content (required and cannot be empty)' });
     }
-    // 400: Enforce a maximum length for the content
+    // 400: Length validation
     if (content.length > 1000) {
         return res.status(400).json({ message: 'Invalid field: content (must be under 1000 characters)' });
     }
 
     try {
-        // 401: Auth logic
+        // 401: Auth resolution from Bearer token
         const authHeader = req.headers.authorization;
         if (!authHeader) {
             return res.status(401).json({ message: "Unauthenticated: No auth token" });
@@ -44,6 +80,8 @@ exports.createTopLevelReply = async (req, res) => {
         }
 
         const auth_user_id = data.user.id;
+
+        // Resolve reply identity defaults from users table
         const userProfile = await replyService.getUserProfile(auth_user_id);
 
         const user = {
@@ -57,7 +95,7 @@ exports.createTopLevelReply = async (req, res) => {
             return res.status(404).json({ message: 'Post not found.' });
         }
 
-        // Call the service to insert the reply
+        // Delegate persistence/business logic to service
         const reply = await replyService.createTopLevelReply(postId, user, content);
 
         // Respond with the created reply
@@ -69,19 +107,33 @@ exports.createTopLevelReply = async (req, res) => {
 };
 
 /**
- * Related: POST /api/replies/:replyId/replies
- * 
- * Controller for creating a nested reply to an existing reply.
+ * POST /api/replies/:replyId/replies
+ *
+ * Creates a nested reply under an existing top-level reply.
+ * Enforces one-level-only nesting.
+ *
+ * Flow:
+ *   1) Validate route params and content
+ *   2) Resolve authenticated user from Bearer token
+ *   3) Load user profile (anonymous_name + language)
+ *   4) Fetch parent reply and validate nesting depth
+ *   5) Delegate insert to service layer
+ *
+ * Returns:
+ *   201 on success
+ *   400 if parent reply is already nested
+ *   401/404 for auth/not-found failures
+ *   500 for unexpected errors
  */
 exports.createNestedReply = async (req, res) => {
     const replyId = req.params.replyId;
     const { content } = req.body || {};
 
-    // 400: Validate replyId
+    // 400: Invalid route param
     if (!isValidUUID(replyId)) {
         return res.status(400).json({ message: 'Invalid field: replyId (must be UUID)' });
     }
-    // 400: Validate content
+    // 400: Invalid or missing content
     if (!content || typeof content !== 'string' || content.trim().length === 0) {
         return res.status(400).json({ message: 'Invalid field: content (required and cannot be empty)' });
     }
@@ -90,7 +142,7 @@ exports.createNestedReply = async (req, res) => {
     }
 
     try {
-        // 401: Auth logic (reuse from createTopLevelReply)
+        // 401: Auth resolution from Bearer token
         const authHeader = req.headers.authorization;
         if (!authHeader) {
             return res.status(401).json({ message: "Unauthenticated: No auth token" });
@@ -105,6 +157,8 @@ exports.createNestedReply = async (req, res) => {
         }
 
         const auth_user_id = data.user.id;
+
+        // Resolve reply identity defaults from users table
         const userProfile = await replyService.getUserProfile(auth_user_id);
 
         const user = {
@@ -113,7 +167,7 @@ exports.createNestedReply = async (req, res) => {
             language: userProfile.language
         };
 
-        // Fetch parent reply
+        // Validate parent reply existence/depth
         const parentReply = await replyService.getReplyById(replyId);
         if (!parentReply) {
             return res.status(404).json({ message: 'Parent reply not found.' });
@@ -123,7 +177,7 @@ exports.createNestedReply = async (req, res) => {
             return res.status(400).json({ message: 'Nesting depth exceeded: Replies can only be nested one level deep.' });
         }
 
-        // Insert nested reply
+        // Delegate persistence/business logic to service
         const reply = await replyService.createNestedReply(parentReply, user, content);
 
         res.status(201).json(reply);
@@ -134,10 +188,18 @@ exports.createNestedReply = async (req, res) => {
 };
 
 /**
- * Related: GET /api/posts/:postId/replies
- * 
- * Controller for fetching all replies for a post.
- * Responds with a placeholder message for now.
+ * GET /api/posts/:postId/replies
+ *
+ * Fetches replies for a post as a flat, paginated list.
+ * Frontend is responsible for nesting using parent_reply_id.
+ *
+ * Query params:
+ *   - page (default: 1)
+ *   - limit (default: 20)
+ *
+ * Returns:
+ *   200 with { replies, total, page, limit }
+ *   400/404/500 for invalid input, not found, or server failures
  */
 exports.getRepliesForPost = async (req, res) => {
     const postId = req.params.postId;

--- a/server/controllers/repliesController.js
+++ b/server/controllers/repliesController.js
@@ -1,3 +1,4 @@
+const supabase = require('../supabaseClient');
 const replyService = require('../services/replyService');
 
 // Regex to validate UUID format
@@ -12,7 +13,7 @@ function isValidUUID(uuid) {
  */
 exports.createTopLevelReply = async (req, res) => {
     const postId = req.params.postId;
-    const { content } = req.body;
+    const { content } = req.body || {};
 
     // 400: Validate postId is in UUID format
     if (!isValidUUID(postId)) {

--- a/server/controllers/repliesController.js
+++ b/server/controllers/repliesController.js
@@ -14,9 +14,19 @@ exports.getRepliesForPost = async (req, res) => {
     if (!isValidUUID(postId)) {
         return res.status(400).json({ message: 'Invalid postId format (must be UUID)' });
     }
+
+    // Parse pagination params with defaults
+    const page = parseInt(req.query.page, 10) || 1;
+    const limit = parseInt(req.query.limit, 10) || 20;
+
     try {
-        const replies = await replyService.getRepliesForPost(postId);
-        res.status(200).json({ replies });
+        const { replies, total } = await replyService.getRepliesForPost(postId, page, limit);
+        res.status(200).json({
+            replies,
+            total,
+            page,
+            limit
+        });
     } catch (err) {
         console.error('Error fetching replies:', err);
         res.status(500).json({ message: 'Error(500):Internal server error' });

--- a/server/controllers/repliesController.js
+++ b/server/controllers/repliesController.js
@@ -8,7 +8,6 @@ function isValidUUID(uuid) {
 /**
  * POST /api/posts/:postId/replies
  * 
- * 
  * Controller for creating a top-level reply to a post.
  */
 exports.createTopLevelReply = async (req, res) => {
@@ -63,6 +62,55 @@ exports.createTopLevelReply = async (req, res) => {
         res.status(201).json(reply);
     } catch (err) {
         console.error('Error creating reply:', err);
+        res.status(500).json({ message: 'Internal server error' });
+    }
+};
+
+/**
+ * POST /api/replies/:replyId/replies
+ * 
+ * Controller for creating a nested reply to an existing reply.
+ */
+exports.createNestedReply = async (req, res) => {
+    const replyId = req.params.replyId;
+    const { content } = req.body || {};
+
+    // Validate replyId
+    if (!isValidUUID(replyId)) {
+        return res.status(400).json({ message: 'Invalid replyId format (must be UUID)' });
+    }
+    // Validate content
+    if (!content || typeof content !== 'string' || content.trim().length === 0) {
+        return res.status(400).json({ message: 'Content is required and cannot be empty.' });
+    }
+    if (content.length > 1000) {
+        return res.status(400).json({ message: 'Content must be under 1000 characters.' });
+    }
+
+    // (Optional) Auth logic (reuse from createTopLevelReply)
+    // For now, use a placeholder user object if skipping auth:
+    const user = {
+        id: "test-user-id",
+        username: "TestUser",
+        language: "English"
+    };
+
+    try {
+        // Fetch parent reply
+        const parentReply = await replyService.getReplyById(replyId);
+        if (!parentReply) {
+            return res.status(404).json({ message: 'Parent reply not found.' });
+        }
+        if (parentReply.parent_reply_id !== null) {
+            return res.status(400).json({ message: 'Replies can only be nested one level deep.' });
+        }
+
+        // Insert nested reply
+        const reply = await replyService.createNestedReply(parentReply, user, content);
+
+        res.status(201).json(reply);
+    } catch (err) {
+        console.error('Error creating nested reply:', err);
         res.status(500).json({ message: 'Internal server error' });
     }
 };

--- a/server/controllers/repliesController.js
+++ b/server/controllers/repliesController.js
@@ -1,0 +1,7 @@
+/**
+ * Controller for fetching all replies for a post.
+ * Responds with a placeholder message for now.
+ */
+exports.getRepliesForPost = (req, res) => {
+  res.status(501).json({ message: 'Not implemented(GET): fetch replies for post (controller)' });
+};

--- a/server/controllers/repliesController.js
+++ b/server/controllers/repliesController.js
@@ -30,6 +30,18 @@ exports.createTopLevelReply = async (req, res) => {
         return res.status(400).json({ message: 'Content must be under 1000 characters.' });
     }
 
+    // Check if post exists
+    try {
+        const postExists = await replyService.checkPostExists(postId);
+        if (!postExists) {
+            return res.status(404).json({ message: 'Post not found.' });
+        }
+        res.status(501).json({ message: 'Not implemented: post existence check done' });
+    } catch (err) {
+        console.error('Error checking post existence:', err);
+        res.status(500).json({ message: 'Internal server error' });
+    }
+
     res.status(501).json({ message: 'Not implemented: create top-level reply (validation done)' });
 };
 

--- a/server/controllers/repliesController.js
+++ b/server/controllers/repliesController.js
@@ -1,7 +1,15 @@
+const replyService = require('../services/replyService');
+
 /**
  * Controller for fetching all replies for a post.
  * Responds with a placeholder message for now.
  */
-exports.getRepliesForPost = (req, res) => {
-  res.status(501).json({ message: 'Not implemented(GET): fetch replies for post (controller)' });
+exports.getRepliesForPost = async (req, res) => {
+    try {
+        // Call the service function (not implemented yet)
+        const replies = await replyService.getRepliesForPost(req.params.postId);
+        res.status(200).json({ replies });
+    } catch (err) {
+        res.status(500).json({ message: 'Error(500):Internal server error' });
+    }
 };

--- a/server/controllers/repliesController.js
+++ b/server/controllers/repliesController.js
@@ -14,31 +14,31 @@ exports.createTopLevelReply = async (req, res) => {
     const postId = req.params.postId;
     const { content } = req.body;
 
-    // Validate postId is in UUID format
+    // 400: Validate postId is in UUID format
     if (!isValidUUID(postId)) {
-        return res.status(400).json({ message: 'Invalid postId format (must be UUID)' });
+        return res.status(400).json({ message: 'Invalid field: postId (must be UUID)' });
     }
-    // Validate content of reply after trimming it
+    // 400: Validate content of reply after trimming it
     if (!content || typeof content !== 'string' || content.trim().length === 0) {
-        return res.status(400).json({ message: 'Content is required and cannot be empty.' });
+        return res.status(400).json({ message: 'Invalid field: content (required and cannot be empty)' });
     }
-    // Enforce a maximum length for the content
+    // 400: Enforce a maximum length for the content
     if (content.length > 1000) {
-        return res.status(400).json({ message: 'Content must be under 1000 characters.' });
+        return res.status(400).json({ message: 'Invalid field: content (must be under 1000 characters)' });
     }
 
-    // Auth logic
+    // 401: Auth logic
     const authHeader = req.headers.authorization;
     if (!authHeader) {
-        return res.status(401).json({ message: "No auth token" });
+        return res.status(401).json({ message: "Unauthenticated: No auth token" });
     }
     const [scheme, token] = authHeader.split(" ");
     if (scheme !== "Bearer" || !token) {
-        return res.status(401).json({ message: "Invalid authorization format" });
+        return res.status(401).json({ message: "Unauthenticated: Invalid authorization format" });
     }
     const { data, error } = await supabase.auth.getUser(token);
     if (error || !data.user) {
-        return res.status(401).json({ message: "Invalid token" });
+        return res.status(401).json({ message: "Unauthenticated: Invalid token" });
     }
     const auth_user_id = data.user.id;
 
@@ -75,19 +75,19 @@ exports.createNestedReply = async (req, res) => {
     const replyId = req.params.replyId;
     const { content } = req.body || {};
 
-    // Validate replyId
+    // 400: Validate replyId
     if (!isValidUUID(replyId)) {
-        return res.status(400).json({ message: 'Invalid replyId format (must be UUID)' });
+        return res.status(400).json({ message: 'Invalid field: replyId (must be UUID)' });
     }
-    // Validate content
+    // 400: Validate content
     if (!content || typeof content !== 'string' || content.trim().length === 0) {
-        return res.status(400).json({ message: 'Content is required and cannot be empty.' });
+        return res.status(400).json({ message: 'Invalid field: content (required and cannot be empty)' });
     }
     if (content.length > 1000) {
-        return res.status(400).json({ message: 'Content must be under 1000 characters.' });
+        return res.status(400).json({ message: 'Invalid field: content (must be under 1000 characters)' });
     }
 
-    // (Optional) Auth logic (reuse from createTopLevelReply)
+    // 401: (Optional) Auth logic (reuse from createTopLevelReply)
     // For now, use a placeholder user object if skipping auth:
     const user = {
         id: "test-user-id",
@@ -101,8 +101,9 @@ exports.createNestedReply = async (req, res) => {
         if (!parentReply) {
             return res.status(404).json({ message: 'Parent reply not found.' });
         }
+        // 400: Enforce one-level nesting
         if (parentReply.parent_reply_id !== null) {
-            return res.status(400).json({ message: 'Replies can only be nested one level deep.' });
+            return res.status(400).json({ message: 'Nesting depth exceeded: Replies can only be nested one level deep.' });
         }
 
         // Insert nested reply

--- a/server/controllers/repliesController.js
+++ b/server/controllers/repliesController.js
@@ -28,29 +28,30 @@ exports.createTopLevelReply = async (req, res) => {
         return res.status(400).json({ message: 'Invalid field: content (must be under 1000 characters)' });
     }
 
-    // 401: Auth logic
-    const authHeader = req.headers.authorization;
-    if (!authHeader) {
-        return res.status(401).json({ message: "Unauthenticated: No auth token" });
-    }
-    const [scheme, token] = authHeader.split(" ");
-    if (scheme !== "Bearer" || !token) {
-        return res.status(401).json({ message: "Unauthenticated: Invalid authorization format" });
-    }
-    const { data, error } = await supabase.auth.getUser(token);
-    if (error || !data.user) {
-        return res.status(401).json({ message: "Unauthenticated: Invalid token" });
-    }
-    const auth_user_id = data.user.id;
-
-    // For now, use a placeholder user object if skipping real user lookup
-    const user = {
-        id: auth_user_id, // Replace with real user id when ready
-        username: "TestUser", // Replace with real username from DB
-        language: "English"   // Replace with real language from DB
-    };
-
     try {
+        // 401: Auth logic
+        const authHeader = req.headers.authorization;
+        if (!authHeader) {
+            return res.status(401).json({ message: "Unauthenticated: No auth token" });
+        }
+        const [scheme, token] = authHeader.split(" ");
+        if (scheme !== "Bearer" || !token) {
+            return res.status(401).json({ message: "Unauthenticated: Invalid authorization format" });
+        }
+        const { data, error } = await supabase.auth.getUser(token);
+        if (error || !data.user) {
+            return res.status(401).json({ message: "Unauthenticated: Invalid token" });
+        }
+
+        const auth_user_id = data.user.id;
+        const userProfile = await replyService.getUserProfile(auth_user_id);
+
+        const user = {
+            id: auth_user_id,
+            anonymous_name: userProfile.anonymous_name,
+            language: userProfile.language
+        };
+
         const postExists = await replyService.checkPostExists(postId);
         if (!postExists) {
             return res.status(404).json({ message: 'Post not found.' });
@@ -88,15 +89,30 @@ exports.createNestedReply = async (req, res) => {
         return res.status(400).json({ message: 'Invalid field: content (must be under 1000 characters)' });
     }
 
-    // 401: (Optional) Auth logic (reuse from createTopLevelReply)
-    // For now, use a placeholder user object if skipping auth:
-    const user = {
-        id: "test-user-id",
-        username: "TestUser",
-        language: "English"
-    };
-
     try {
+        // 401: Auth logic (reuse from createTopLevelReply)
+        const authHeader = req.headers.authorization;
+        if (!authHeader) {
+            return res.status(401).json({ message: "Unauthenticated: No auth token" });
+        }
+        const [scheme, token] = authHeader.split(" ");
+        if (scheme !== "Bearer" || !token) {
+            return res.status(401).json({ message: "Unauthenticated: Invalid authorization format" });
+        }
+        const { data, error } = await supabase.auth.getUser(token);
+        if (error || !data.user) {
+            return res.status(401).json({ message: "Unauthenticated: Invalid token" });
+        }
+
+        const auth_user_id = data.user.id;
+        const userProfile = await replyService.getUserProfile(auth_user_id);
+
+        const user = {
+            id: auth_user_id,
+            anonymous_name: userProfile.anonymous_name,
+            language: userProfile.language
+        };
+
         // Fetch parent reply
         const parentReply = await replyService.getReplyById(replyId);
         if (!parentReply) {
@@ -134,6 +150,11 @@ exports.getRepliesForPost = async (req, res) => {
     const limit = parseInt(req.query.limit, 10) || 20;
 
     try {
+        const postExists = await replyService.checkPostExists(postId);
+        if (!postExists) {
+            return res.status(404).json({ message: 'Post not found.' });
+        }
+
         const { replies, total } = await replyService.getRepliesForPost(postId, page, limit);
         res.status(200).json({
             replies,

--- a/server/index.js
+++ b/server/index.js
@@ -27,6 +27,9 @@ app.get('/api/health', (req, res) => {
 
 app.use('/api/prompts', promptRoutes);
 
+const replyRoutes = require('./routes/replies');
+app.use('/api', replyRoutes);
+
 // Start server
 app.listen(PORT, () => {
   console.log(`Server is running on http://localhost:${PORT}`);

--- a/server/routes/replies.js
+++ b/server/routes/replies.js
@@ -1,6 +1,7 @@
 // Import the Express library and create a new router object from Express
 const express = require('express');
 const router = express.Router();
+const repliesController = require('../controllers/repliesController');
 
 /**
  * 'Test' endpoint for the replies route, this will response to GET requests at
@@ -19,7 +20,7 @@ router.get('/test', (req, res) => {
  * Example: POST http://localhost:3000/api/posts/123/replies
  */
 router.post('/posts/:postId/replies', (req, res) => {
-  res.status(501).json({ message: 'Not implemented: create top-level reply' });
+  res.status(501).json({ message: 'Not implemented(POST): create top-level reply' });
 });
 
 /**
@@ -29,18 +30,16 @@ router.post('/posts/:postId/replies', (req, res) => {
  * Example: POST http://localhost:3000/replies/456/replies
  */
 router.post('/replies/:replyId/replies', (req, res) => {
-  res.status(501).json({ message: 'Not implemented: create nested reply' });
+  res.status(501).json({ message: 'Not implemented(POST): create nested reply' });
 });
 
 /**
  * GET /api/posts/:postId/replies
- * Placeholder for fetching all replies for a post.
  * 
  Example: GET http://localhost:3000/api/posts/123/replies
  */
-router.get('/posts/:postId/replies', (req, res) => {
-  res.status(501).json({ message: 'Not implemented: fetch replies for post' });
-});
+router.get('/posts/:postId/replies', repliesController.getRepliesForPost);
+
 
 // Export the router object so it can be used in other parts of the application
 module.exports = router;

--- a/server/routes/replies.js
+++ b/server/routes/replies.js
@@ -3,13 +3,43 @@ const express = require('express');
 const router = express.Router();
 
 /**
- * Test endpoint for the replies route, this will response to GET requests at
+ * 'Test' endpoint for the replies route, this will response to GET requests at
  * /api/test with a JSON message confirming that the route is working. 
  * 
  * Example: GET http://localhost:3000/api/test
  */
 router.get('/test', (req, res) => {
   res.status(200).json({ message: 'Replies route is working!' });
+});
+
+/**
+ * POST /api/posts/:postId/replies
+ * Placeholder for creating a top-level reply.
+ * 
+ * Example: POST http://localhost:3000/api/posts/123/replies
+ */
+router.post('/posts/:postId/replies', (req, res) => {
+  res.status(501).json({ message: 'Not implemented: create top-level reply' });
+});
+
+/**
+ * POST /api/replies/:replyId/replies
+ * Placeholder for creating a nested reply.
+ * 
+ * Example: POST http://localhost:3000/replies/456/replies
+ */
+router.post('/replies/:replyId/replies', (req, res) => {
+  res.status(501).json({ message: 'Not implemented: create nested reply' });
+});
+
+/**
+ * GET /api/posts/:postId/replies
+ * Placeholder for fetching all replies for a post.
+ * 
+ Example: GET http://localhost:3000/api/posts/123/replies
+ */
+router.get('/posts/:postId/replies', (req, res) => {
+  res.status(501).json({ message: 'Not implemented: fetch replies for post' });
 });
 
 // Export the router object so it can be used in other parts of the application

--- a/server/routes/replies.js
+++ b/server/routes/replies.js
@@ -23,13 +23,11 @@ router.post('/posts/:postId/replies', repliesController.createTopLevelReply);
 
 /**
  * POST /api/replies/:replyId/replies
- * Placeholder for creating a nested reply.
+ * Create a nested reply.
  * 
  * Example: POST http://localhost:3000/replies/456/replies
  */
-router.post('/replies/:replyId/replies', (req, res) => {
-    res.status(501).json({ message: 'Not implemented(POST): create nested reply' });
-});
+router.post('/replies/:replyId/replies', repliesController.createNestedReply);
 
 /**
  * GET /api/posts/:postId/replies

--- a/server/routes/replies.js
+++ b/server/routes/replies.js
@@ -10,7 +10,7 @@ const repliesController = require('../controllers/repliesController');
  * Example: GET http://localhost:3000/api/test
  */
 router.get('/test', (req, res) => {
-  res.status(200).json({ message: 'Replies route is working!' });
+    res.status(200).json({ message: 'Replies route is working!' });
 });
 
 /**
@@ -20,7 +20,7 @@ router.get('/test', (req, res) => {
  * Example: POST http://localhost:3000/api/posts/123/replies
  */
 router.post('/posts/:postId/replies', (req, res) => {
-  res.status(501).json({ message: 'Not implemented(POST): create top-level reply' });
+    res.status(501).json({ message: 'Not implemented(POST): create top-level reply' });
 });
 
 /**
@@ -30,7 +30,7 @@ router.post('/posts/:postId/replies', (req, res) => {
  * Example: POST http://localhost:3000/replies/456/replies
  */
 router.post('/replies/:replyId/replies', (req, res) => {
-  res.status(501).json({ message: 'Not implemented(POST): create nested reply' });
+    res.status(501).json({ message: 'Not implemented(POST): create nested reply' });
 });
 
 /**

--- a/server/routes/replies.js
+++ b/server/routes/replies.js
@@ -19,9 +19,7 @@ router.get('/test', (req, res) => {
  * 
  * Example: POST http://localhost:3000/api/posts/123/replies
  */
-router.post('/posts/:postId/replies', (req, res) => {
-    res.status(501).json({ message: 'Not implemented(POST): create top-level reply' });
-});
+router.post('/posts/:postId/replies', repliesController.createTopLevelReply);
 
 /**
  * POST /api/replies/:replyId/replies

--- a/server/routes/replies.js
+++ b/server/routes/replies.js
@@ -1,0 +1,16 @@
+// Import the Express library and create a new router object from Express
+const express = require('express');
+const router = express.Router();
+
+/**
+ * Test endpoint for the replies route, this will response to GET requests at
+ * /api/test with a JSON message confirming that the route is working. 
+ * 
+ * Example: GET http://localhost:3000/api/test
+ */
+router.get('/test', (req, res) => {
+  res.status(200).json({ message: 'Replies route is working!' });
+});
+
+// Export the router object so it can be used in other parts of the application
+module.exports = router;

--- a/server/routes/replies.js
+++ b/server/routes/replies.js
@@ -1,12 +1,30 @@
-// Import the Express library and create a new router object from Express
+/**
+ * -----------------------------------------------------------------------------
+ * Replies Routes
+ * -----------------------------------------------------------------------------
+ * Purpose:
+ *   Defines HTTP routes for reply-related API endpoints.
+ *
+ * How this file connects to others:
+ *   - Mounted in server/index.js under /api
+ *   - Delegates request handling to controllers/repliesController.js
+ *   - Controllers then call services/replyService.js for business/data logic
+ *
+ * Notes:
+ *   - Routes should stay thin (path + method + controller binding only).
+ *   - Validation, auth, and DB behavior belong in controller/service layers.
+ * -----------------------------------------------------------------------------
+ */
+
 const express = require('express');
 const router = express.Router();
 const repliesController = require('../controllers/repliesController');
 
 /**
- * 'Test' endpoint for the replies route, this will response to GET requests at
- * /api/test with a JSON message confirming that the route is working. 
- * 
+ * Health/test endpoint for reply routes.
+ * Confirms that the replies router is mounted and reachable.
+ *
+ * Route:
  * Example: GET http://localhost:3000/api/test
  */
 router.get('/test', (req, res) => {
@@ -14,28 +32,43 @@ router.get('/test', (req, res) => {
 });
 
 /**
- * POST /api/posts/:postId/replies
- * Placeholder for creating a top-level reply.
- * 
+ * Create a top-level reply on a post.
+ *
+ * Route:
+ *   POST /api/posts/:postId/replies
+ *
+ * Delegates to:
+ *   repliesController.createTopLevelReply
+ *
  * Example: POST http://localhost:3000/api/posts/123/replies
  */
 router.post('/posts/:postId/replies', repliesController.createTopLevelReply);
 
 /**
- * POST /api/replies/:replyId/replies
  * Create a nested reply.
- * 
+ *
+ * Route:
+ *   POST /api/replies/:replyId/replies
+ *
+ * Delegates to:
+ *   repliesController.createNestedReply
+ *
  * Example: POST http://localhost:3000/replies/456/replies
  */
 router.post('/replies/:replyId/replies', repliesController.createNestedReply);
 
 /**
- * GET /api/posts/:postId/replies
- * 
- Example: GET http://localhost:3000/api/posts/123/replies
+ * Fetch replies for a post (flat list, paginated).
+ *
+ * Route:
+ *   GET /api/posts/:postId/replies
+ *
+ * Delegates to:
+ *   repliesController.getRepliesForPost
+ *
+ * Example: GET http://localhost:3000/api/posts/123/replies?page=1&limit=20
  */
 router.get('/posts/:postId/replies', repliesController.getRepliesForPost);
 
-
-// Export the router object so it can be used in other parts of the application
+// Export router for mounting in server/index.js
 module.exports = router;

--- a/server/services/replyService.js
+++ b/server/services/replyService.js
@@ -8,6 +8,19 @@ exports.createTopLevelReply = async (postId, user, content) => {
   return null;
 };
 
+exports.checkPostExists = async (postId) => {
+    const { data, error } = await supabase
+        .from('posts')
+        .select('id')
+        .eq('id', postId)
+        .single();
+
+    if (error && error.code !== 'PGRST116') { // PGRST116 = no rows found
+        throw error;
+    }
+    return !!data;
+};
+
 /**
  * Service for fetching all replies for a post. 
  * Supports pagination via page and limit parameters(20 messages per page). 

--- a/server/services/replyService.js
+++ b/server/services/replyService.js
@@ -1,19 +1,28 @@
 const supabase = require('../supabaseClient');
 
 /**
- * Service for fetching all replies for a post.
+ * Service for fetching all replies for a post. 
+ * Supports pagination via page and limit parameters(20 messages per page). 
+ * 
+ * Return:Object containing the list of replies and the total count.
  */
-exports.getRepliesForPost = async (postId) => {
-    // Fetch replies for the given postId, ordered by created_at ASC
-    const { data, error } = await supabase
+exports.getRepliesForPost = async (postId, page = 1, limit = 20) => {
+    const from = (page - 1) * limit;
+    const to = from + limit - 1;
+    // Fetch replies for the given postId, ordered by created_at ASC, with pagination support
+    const { data, error, count } = await supabase
         .from('replies')
-        .select('id, post_id, parent_reply_id, anonymous_name, content, language, created_at')
+        .select('id, post_id, parent_reply_id, anonymous_name, content, language, created_at', { count: 'exact' })
         .eq('post_id', postId)
-        .order('created_at', { ascending: true });
+        .order('created_at', { ascending: true })
+        .range(from, to);
 
     if (error) {
         throw error;
     }
 
-    return data || [];
+    return {
+        replies: data || [],
+        total: count || 0
+    };
 };

--- a/server/services/replyService.js
+++ b/server/services/replyService.js
@@ -16,7 +16,7 @@ exports.createTopLevelReply = async (postId, user, content) => {
             post_id: postId,
             parent_reply_id: null,
             user_id: user.id,
-            anonymous_name: user.username,
+            anonymous_name: user.anonymous_name,
             content: content.trim(),
             language: user.language,
             is_flagged: isFlagged
@@ -56,7 +56,7 @@ exports.createNestedReply = async (parentReply, user, content) => {
             post_id: parentReply.post_id,
             parent_reply_id: parentReply.id,
             user_id: user.id,
-            anonymous_name: user.username,
+            anonymous_name: user.anonymous_name,
             content: content.trim(),
             language: user.language,
             is_flagged: isFlagged
@@ -119,6 +119,24 @@ exports.checkPostExists = async (postId) => {
     }
 
     return !!data;
+};
+
+exports.getUserProfile = async (authUserId) => {
+    const { data, error } = await supabase
+        .from('users')
+        .select('anonymous_name, language')
+        .eq('id', authUserId)
+        .single();
+
+    if (error) {
+        throw error;
+    }
+
+    if (!data?.anonymous_name || !data?.language) {
+        throw new Error('User profile not found');
+    }
+
+    return data;
 };
 
 function containsEmailOrPhone(text) {

--- a/server/services/replyService.js
+++ b/server/services/replyService.js
@@ -1,6 +1,14 @@
 const supabase = require('../supabaseClient');
 
 /**
+ * Service for handling replies related operations, such as creating replies and fetching replies for a post.
+ */
+exports.createTopLevelReply = async (postId, user, content) => {
+  // Placeholder for now
+  return null;
+};
+
+/**
  * Service for fetching all replies for a post. 
  * Supports pagination via page and limit parameters(20 messages per page). 
  * 

--- a/server/services/replyService.js
+++ b/server/services/replyService.js
@@ -1,15 +1,40 @@
 const supabase = require('../supabaseClient');
 
 /**
- * Related: POST /api/posts/:postId/replies
- * 
- * Service for handling replies related operations, such as creating replies and fetching replies for a post.
+ * -----------------------------------------------------------------------------
+ * Replies Service
+ * -----------------------------------------------------------------------------
+ * Purpose:
+ *   Encapsulates reply-related business logic and data access.
+ *
+ * How this file connects to others:
+ *   - Called by controllers/repliesController.js
+ *   - Uses server/supabaseClient.js for database operations
+ *   - Powers routes in routes/replies.js through controller delegation
+ *
+ * Responsibilities:
+ *   - Create top-level and nested replies
+ *   - Fetch paginated replies for a post
+ *   - Enforce/assist reply constraints (post existence checks, parent lookup)
+ *   - Apply content flagging + moderation logging
+ *   - Update reply_count on parent posts
+ *   - Shape public API reply payloads by removing internal fields
+ * -----------------------------------------------------------------------------
+ */
+
+/**
+ * Create a top-level reply.
+ *
+ * @param {string} postId - Parent post UUID.
+ * @param {{ id: string, anonymous_name: string, language: string }} user
+ * @param {string} content
+ * @returns {Promise<object>} Public reply shape.
  */
 exports.createTopLevelReply = async (postId, user, content) => {
     // Content safety filtering: Check if content contains email or phone number and flag it if so
     const isFlagged = containsEmailOrPhone(content);
 
-    // Insert the reply into Supabase
+    // Insert reply row and fetch inserted data
     const { data, error } = await supabase
         .from('replies')
         .insert([{
@@ -28,26 +53,31 @@ exports.createTopLevelReply = async (postId, user, content) => {
         throw error;
     }
 
-    // Log to moderation if flagged
+    // Optional moderation side effect
     if (data.is_flagged) {
         await exports.logModerationFlag(data, "auto-flagged: email/phone detected");
     }
 
     await exports.incrementReplyCount(postId);
 
+    // Remove internal fields before controller returns response
     return toPublicReply(data);
 };
 
 /**
- * Related: POST /api/replies/:replyId/replies
- * 
- * Service for creating a nested reply to an existing reply. 
- * 
- * Return: The created nested reply object.
+ * Create a nested reply under a parent reply.
+ *
+ * Note:
+ *   Parent depth validation is performed in the controller before calling this.
+ *
+ * @param {{ id: string, post_id: string }} parentReply
+ * @param {{ id: string, anonymous_name: string, language: string }} user
+ * @param {string} content
+ * @returns {Promise<object>} Public reply shape.
  */
 
 exports.createNestedReply = async (parentReply, user, content) => {
-    // Content safety filtering: Check if content contains email or phone number and flag it if so
+    // Content safety flagging
     const isFlagged = containsEmailOrPhone(content);
 
     const { data, error } = await supabase
@@ -68,23 +98,27 @@ exports.createNestedReply = async (parentReply, user, content) => {
         throw error;
     }
 
-    // Log to moderation if flagged
+    // Optional moderation side effect
     if (data.is_flagged) {
         await exports.logModerationFlag(data, "auto-flagged: email/phone detected");
     }
 
     await exports.incrementReplyCount(parentReply.post_id);
 
+    // Remove internal fields before controller returns response
     return toPublicReply(data);
 };
 
 /**
- * Related: GET /api/posts/:postId/replies
- * 
- * Service for fetching all replies for a post. 
- * Supports pagination via page and limit parameters(20 messages per page). 
- * 
- * Return: Object containing the list of replies and the total count.
+ * Fetch paginated replies for a post.
+ *
+ * Returns replies in chronological order, as a flat list.
+ * Frontend is expected to reconstruct hierarchy via parent_reply_id.
+ *
+ * @param {string} postId
+ * @param {number} page
+ * @param {number} limit
+ * @returns {Promise<{replies: object[], total: number}>}
  */
 exports.getRepliesForPost = async (postId, page = 1, limit = 20) => {
     const from = (page - 1) * limit;
@@ -107,6 +141,12 @@ exports.getRepliesForPost = async (postId, page = 1, limit = 20) => {
     };
 };
 
+/**
+ * Check whether a post exists.
+ *
+ * @param {string} postId
+ * @returns {Promise<boolean>}
+ */
 exports.checkPostExists = async (postId) => {
     const { data, error } = await supabase
         .from('posts')
@@ -121,6 +161,12 @@ exports.checkPostExists = async (postId) => {
     return !!data;
 };
 
+/**
+ * Resolve reply identity defaults from users table.
+ *
+ * @param {string} authUserId
+ * @returns {Promise<{anonymous_name: string, language: string}>}
+ */
 exports.getUserProfile = async (authUserId) => {
     const { data, error } = await supabase
         .from('users')
@@ -146,6 +192,12 @@ function containsEmailOrPhone(text) {
     return emailRegex.test(text) || phoneRegex.test(text);
 }
 
+/**
+ * Increment reply_count on a post.
+ *
+ * @param {string} postId
+ * @returns {Promise<void>}
+ */
 exports.incrementReplyCount = async (postId) => {
     // Fetch current count
     const { data, error: fetchError } = await supabase
@@ -167,6 +219,14 @@ exports.incrementReplyCount = async (postId) => {
     if (updateError) throw updateError;
 };
 
+/**
+ * Fetch a reply by ID.
+ *
+ * Used by controller to validate nested-reply parent existence/depth.
+ *
+ * @param {string} replyId
+ * @returns {Promise<{id: string, post_id: string, parent_reply_id: string | null} | null>}
+ */
 exports.getReplyById = async (replyId) => {
     const { data, error } = await supabase
         .from('replies')
@@ -180,6 +240,13 @@ exports.getReplyById = async (replyId) => {
     return data;
 };
 
+/**
+ * Write moderation audit record for flagged reply content.
+ *
+ * @param {{ id: string, user_id: string, content: string }} reply
+ * @param {string} reason
+ * @returns {Promise<void>}
+ */
 exports.logModerationFlag = async (reply, reason) => {
     const { error } = await supabase
         .from('moderation_logs')

--- a/server/services/replyService.js
+++ b/server/services/replyService.js
@@ -6,6 +6,9 @@ const supabase = require('../supabaseClient');
  * Service for handling replies related operations, such as creating replies and fetching replies for a post.
  */
 exports.createTopLevelReply = async (postId, user, content) => {
+    // Content safety filtering: Check if content contains email or phone number and flag it if so
+    const isFlagged = containsEmailOrPhone(content);
+
     // Insert the reply into Supabase
     const { data, error } = await supabase
       .from('replies')
@@ -29,40 +32,6 @@ exports.createTopLevelReply = async (postId, user, content) => {
     return data;
 };
 
-exports.incrementReplyCount = async (postId) => {
-    // Fetch current count
-    const { data, error: fetchError } = await supabase
-        .from('posts')
-        .select('reply_count')
-        .eq('id', postId)
-        .single();
-
-    if (fetchError) throw fetchError;
-
-    const newCount = (data.reply_count || 0) + 1;
-
-    // Update count
-    const { error: updateError } = await supabase
-        .from('posts')
-        .update({ reply_count: newCount })
-        .eq('id', postId);
-
-    if (updateError) throw updateError;
-};
-
-exports.getReplyById = async (replyId) => {
-    const { data, error } = await supabase
-        .from('replies')
-        .select('id, post_id, parent_reply_id')
-        .eq('id', replyId)
-        .single();
-
-    if (error && error.code !== 'PGRST116') {
-        throw error;
-    }
-    return data;
-};
-
 /**
  * Related: POST /api/replies/:replyId/replies
  * 
@@ -72,6 +41,9 @@ exports.getReplyById = async (replyId) => {
  */
 
 exports.createNestedReply = async (parentReply, user, content) => {
+    // Content safety filtering: Check if content contains email or phone number and flag it if so
+    const isFlagged = containsEmailOrPhone(content);
+
     const { data, error } = await supabase
         .from('replies')
         .insert([{
@@ -121,4 +93,45 @@ exports.getRepliesForPost = async (postId, page = 1, limit = 20) => {
         replies: data || [],
         total: count || 0
     };
+};
+
+function containsEmailOrPhone(text) {
+    // Simple regex for email and phone (can be improved)
+    const emailRegex = /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b/;
+    const phoneRegex = /\b\d{3}[-.\s]?\d{3}[-.\s]?\d{4}\b/;
+    return emailRegex.test(text) || phoneRegex.test(text);
+}
+
+exports.incrementReplyCount = async (postId) => {
+    // Fetch current count
+    const { data, error: fetchError } = await supabase
+        .from('posts')
+        .select('reply_count')
+        .eq('id', postId)
+        .single();
+
+    if (fetchError) throw fetchError;
+
+    const newCount = (data.reply_count || 0) + 1;
+
+    // Update count
+    const { error: updateError } = await supabase
+        .from('posts')
+        .update({ reply_count: newCount })
+        .eq('id', postId);
+
+    if (updateError) throw updateError;
+};
+
+exports.getReplyById = async (replyId) => {
+    const { data, error } = await supabase
+        .from('replies')
+        .select('id, post_id, parent_reply_id')
+        .eq('id', replyId)
+        .single();
+
+    if (error && error.code !== 'PGRST116') {
+        throw error;
+    }
+    return data;
 };

--- a/server/services/replyService.js
+++ b/server/services/replyService.js
@@ -1,0 +1,8 @@
+/**
+ * Service for fetching all replies for a post.
+ * For now, returns a placeholder array.
+ */
+exports.getRepliesForPost = async (postId) => {
+    // Placeholder: return an empty array
+    return [];
+};

--- a/server/services/replyService.js
+++ b/server/services/replyService.js
@@ -11,20 +11,26 @@ exports.createTopLevelReply = async (postId, user, content) => {
 
     // Insert the reply into Supabase
     const { data, error } = await supabase
-      .from('replies')
-      .insert([{
-        post_id: postId,
-        parent_reply_id: null,
-        user_id: user.id,
-        anonymous_name: user.username,
-        content: content.trim(),
-        language: user.language
-      }])
-      .select('id, post_id, parent_reply_id, anonymous_name, content, language, created_at')
-      .single();
+        .from('replies')
+        .insert([{
+            post_id: postId,
+            parent_reply_id: null,
+            user_id: user.id,
+            anonymous_name: user.username,
+            content: content.trim(),
+            language: user.language,
+            is_flagged: isFlagged
+        }])
+        .select('id, post_id, parent_reply_id, anonymous_name, content, language, is_flagged, user_id, created_at')
+        .single();
 
     if (error) {
-      throw error;
+        throw error;
+    }
+
+    // Log to moderation if flagged
+    if (data.is_flagged) {
+        await exports.logModerationFlag(data, "auto-flagged: email/phone detected");
     }
 
     await exports.incrementReplyCount(postId);
@@ -52,13 +58,19 @@ exports.createNestedReply = async (parentReply, user, content) => {
             user_id: user.id,
             anonymous_name: user.username,
             content: content.trim(),
-            language: user.language
+            language: user.language,
+            is_flagged: isFlagged
         }])
-        .select('id, post_id, parent_reply_id, anonymous_name, content, language, created_at')
+        .select('id, post_id, parent_reply_id, anonymous_name, content, language, is_flagged, user_id, created_at')
         .single();
 
     if (error) {
         throw error;
+    }
+
+    // Log to moderation if flagged
+    if (data.is_flagged) {
+        await exports.logModerationFlag(data, "auto-flagged: email/phone detected");
     }
 
     await exports.incrementReplyCount(parentReply.post_id);
@@ -134,4 +146,17 @@ exports.getReplyById = async (replyId) => {
         throw error;
     }
     return data;
+};
+
+exports.logModerationFlag = async (reply, reason) => {
+    const { error } = await supabase
+        .from('moderation_logs')
+        .insert([{
+            reply_id: reply.id,
+            user_id: reply.user_id,
+            content: reply.content,
+            reason: reason,
+            created_at: new Date().toISOString()
+        }]);
+    if (error) throw error;
 };

--- a/server/services/replyService.js
+++ b/server/services/replyService.js
@@ -35,7 +35,7 @@ exports.createTopLevelReply = async (postId, user, content) => {
 
     await exports.incrementReplyCount(postId);
 
-    return data;
+    return toPublicReply(data);
 };
 
 /**
@@ -75,7 +75,7 @@ exports.createNestedReply = async (parentReply, user, content) => {
 
     await exports.incrementReplyCount(parentReply.post_id);
 
-    return data;
+    return toPublicReply(data);
 };
 
 /**
@@ -105,6 +105,20 @@ exports.getRepliesForPost = async (postId, page = 1, limit = 20) => {
         replies: data || [],
         total: count || 0
     };
+};
+
+exports.checkPostExists = async (postId) => {
+    const { data, error } = await supabase
+        .from('posts')
+        .select('id')
+        .eq('id', postId)
+        .maybeSingle();
+
+    if (error) {
+        throw error;
+    }
+
+    return !!data;
 };
 
 function containsEmailOrPhone(text) {
@@ -160,3 +174,12 @@ exports.logModerationFlag = async (reply, reason) => {
         }]);
     if (error) throw error;
 };
+
+function toPublicReply(reply) {
+    if (!reply) {
+        return reply;
+    }
+
+    const { user_id, is_flagged, updated_at, ...publicReply } = reply;
+    return publicReply;
+}

--- a/server/services/replyService.js
+++ b/server/services/replyService.js
@@ -1,6 +1,8 @@
 const supabase = require('../supabaseClient');
 
 /**
+ * Related: POST /api/posts/:postId/replies
+ * 
  * Service for handling replies related operations, such as creating replies and fetching replies for a post.
  */
 exports.createTopLevelReply = async (postId, user, content) => {
@@ -25,11 +27,55 @@ exports.createTopLevelReply = async (postId, user, content) => {
   return data;
 };
 
+exports.getReplyById = async (replyId) => {
+    const { data, error } = await supabase
+        .from('replies')
+        .select('id, post_id, parent_reply_id')
+        .eq('id', replyId)
+        .single();
+
+    if (error && error.code !== 'PGRST116') {
+        throw error;
+    }
+    return data;
+};
+
 /**
+ * Related: POST /api/replies/:replyId/replies
+ * 
+ * Service for creating a nested reply to an existing reply. 
+ * 
+ * Return: The created nested reply object.
+ */
+
+exports.createNestedReply = async (parentReply, user, content) => {
+    const { data, error } = await supabase
+        .from('replies')
+        .insert([{
+            post_id: parentReply.post_id,
+            parent_reply_id: parentReply.id,
+            user_id: user.id,
+            anonymous_name: user.username,
+            content: content.trim(),
+            language: user.language
+        }])
+        .select('id, post_id, parent_reply_id, anonymous_name, content, language, created_at')
+        .single();
+
+    if (error) {
+        throw error;
+    }
+
+    return data;
+};
+
+/**
+ * Related: GET /api/posts/:postId/replies
+ * 
  * Service for fetching all replies for a post. 
  * Supports pagination via page and limit parameters(20 messages per page). 
  * 
- * Return:Object containing the list of replies and the total count.
+ * Return: Object containing the list of replies and the total count.
  */
 exports.getRepliesForPost = async (postId, page = 1, limit = 20) => {
     const from = (page - 1) * limit;

--- a/server/services/replyService.js
+++ b/server/services/replyService.js
@@ -4,21 +4,25 @@ const supabase = require('../supabaseClient');
  * Service for handling replies related operations, such as creating replies and fetching replies for a post.
  */
 exports.createTopLevelReply = async (postId, user, content) => {
-  // Placeholder for now
-  return null;
-};
+  // Insert the reply into Supabase
+  const { data, error } = await supabase
+    .from('replies')
+    .insert([{
+      post_id: postId,
+      parent_reply_id: null,
+      user_id: user.id,
+      anonymous_name: user.username,
+      content: content.trim(),
+      language: user.language
+    }])
+    .select('id, post_id, parent_reply_id, anonymous_name, content, language, created_at')
+    .single();
 
-exports.checkPostExists = async (postId) => {
-    const { data, error } = await supabase
-        .from('posts')
-        .select('id')
-        .eq('id', postId)
-        .single();
+  if (error) {
+    throw error;
+  }
 
-    if (error && error.code !== 'PGRST116') { // PGRST116 = no rows found
-        throw error;
-    }
-    return !!data;
+  return data;
 };
 
 /**

--- a/server/services/replyService.js
+++ b/server/services/replyService.js
@@ -6,25 +6,48 @@ const supabase = require('../supabaseClient');
  * Service for handling replies related operations, such as creating replies and fetching replies for a post.
  */
 exports.createTopLevelReply = async (postId, user, content) => {
-  // Insert the reply into Supabase
-  const { data, error } = await supabase
-    .from('replies')
-    .insert([{
-      post_id: postId,
-      parent_reply_id: null,
-      user_id: user.id,
-      anonymous_name: user.username,
-      content: content.trim(),
-      language: user.language
-    }])
-    .select('id, post_id, parent_reply_id, anonymous_name, content, language, created_at')
-    .single();
+    // Insert the reply into Supabase
+    const { data, error } = await supabase
+      .from('replies')
+      .insert([{
+        post_id: postId,
+        parent_reply_id: null,
+        user_id: user.id,
+        anonymous_name: user.username,
+        content: content.trim(),
+        language: user.language
+      }])
+      .select('id, post_id, parent_reply_id, anonymous_name, content, language, created_at')
+      .single();
 
-  if (error) {
-    throw error;
-  }
+    if (error) {
+      throw error;
+    }
 
-  return data;
+    await exports.incrementReplyCount(postId);
+
+    return data;
+};
+
+exports.incrementReplyCount = async (postId) => {
+    // Fetch current count
+    const { data, error: fetchError } = await supabase
+        .from('posts')
+        .select('reply_count')
+        .eq('id', postId)
+        .single();
+
+    if (fetchError) throw fetchError;
+
+    const newCount = (data.reply_count || 0) + 1;
+
+    // Update count
+    const { error: updateError } = await supabase
+        .from('posts')
+        .update({ reply_count: newCount })
+        .eq('id', postId);
+
+    if (updateError) throw updateError;
 };
 
 exports.getReplyById = async (replyId) => {
@@ -65,6 +88,8 @@ exports.createNestedReply = async (parentReply, user, content) => {
     if (error) {
         throw error;
     }
+
+    await exports.incrementReplyCount(parentReply.post_id);
 
     return data;
 };

--- a/server/services/replyService.js
+++ b/server/services/replyService.js
@@ -1,8 +1,19 @@
+const supabase = require('../supabaseClient');
+
 /**
  * Service for fetching all replies for a post.
- * For now, returns a placeholder array.
  */
 exports.getRepliesForPost = async (postId) => {
-    // Placeholder: return an empty array
-    return [];
+    // Fetch replies for the given postId, ordered by created_at ASC
+    const { data, error } = await supabase
+        .from('replies')
+        .select('id, post_id, parent_reply_id, anonymous_name, content, language, created_at')
+        .eq('post_id', postId)
+        .order('created_at', { ascending: true });
+
+    if (error) {
+        throw error;
+    }
+
+    return data || [];
 };

--- a/server/services/replyService.js
+++ b/server/services/replyService.js
@@ -1,5 +1,3 @@
-const supabase = require('../supabaseClient');
-
 /**
  * -----------------------------------------------------------------------------
  * Replies Service
@@ -21,6 +19,8 @@ const supabase = require('../supabaseClient');
  *   - Shape public API reply payloads by removing internal fields
  * -----------------------------------------------------------------------------
  */
+
+const supabase = require('../supabaseClient');
 
 /**
  * Create a top-level reply.


### PR DESCRIPTION
# Description

Implements the **Thread/Reply backend API** for nested discussions on posts.

### What was added/updated

- Added and registered reply routes in Express.
- Implemented endpoints:
  - `POST /api/posts/:postId/replies` (top-level reply)
  - `POST /api/replies/:replyId/replies` (nested reply, one-level deep only)
  - `GET /api/posts/:postId/replies` (flat, paginated reply list)
- Added route/controller/service layering for replies:
  - `routes/replies.js`
  - `controllers/repliesController.js`
  - `services/replyService.js`
- Added validation:
  - UUID validation for `postId` / `replyId`
  - `content` required, trimmed, non-empty, max 1000 chars
- Added auth-aware user resolution pattern (session token + users profile lookup).
- Added one-level nesting enforcement:
  - Returns `400` with: `"Replies can only be nested one level deep."`
- Added `reply_count` increment after reply insert.
- Added content safety filtering for personal info patterns (email/phone):
  - Sets `is_flagged = true` when detected
  - Logs flagged replies to `moderation_logs`
- Added/updated error handling to return consistent status codes (`400/401/404/500`).
- Ensured public API responses do **not** expose internal fields (`user_id`, `is_flagged`, `updated_at`).
- Added comprehensive inline and file-level documentation in:
  - `server/routes/replies.js`
  - `server/controllers/repliesController.js`
  - `server/services/replyService.js`

---

# Type of Change(s)

- [x] New feature
- [x] Bug fix
- [x] Refactor
- [ ] CI/CD update
- [ ] Test
- [x] Other (please explain): Documentation overhaul for replies route/controller/service files

---

# How to Test Changes

Note to test you need "POST_ID_UUID" and curl commands. This is because other developers working on their respective sprint 2 tasks will need to complete their logic first. So it may be hard to fully test the reply system and also since the UI is also being worked on so you cant use the website to test. You need to use your terminal to test this reply logic.

### How to Find Your Access Token

**A. Using the Frontend (if you have a login page):**
1. Log in to your app as a user.
2. Open your browser’s Dev Tools (`F12` or right-click → Inspect).
3. Go to the **Application** tab.
4. In the left sidebar, look under **Local Storage** or **Session Storage** for your site (e.g., `http://localhost:5173`).
5. Look for a key like `sb-<project-ref>-auth-token` or `supabase.auth.token`.
6. The value will be a JSON string. Find the `"access_token"` field inside it.
7. Copy the long string value of `"access_token"`.

**B. If your app uses cookies:**
- Check under the **Cookies** section in Dev Tools for a similar key.

### How to Find a Prompt UUID

**A. Using the Supabase Dashboard:**
1. Go to [https://app.supabase.com/](https://app.supabase.com/) and log in.
2. Select your project.
3. In the left sidebar, click **Table Editor** (or **Database** > **Tables**).
4. Click on the `prompts` table.
5. Browse the rows. The `id` column contains the UUIDs for prompts.
6. Copy one of the UUIDs from the `id` column.

## 1) Start app
From project root:
```bash
npm run dev
```

## 2) Verify GET replies (pagination + flat shape)
```bash
curl "http://localhost:3000/api/posts/<POST_ID_UUID>/replies?page=1&limit=20"
```
Expected:
- `200 OK`
- JSON shape:
  - `replies` (flat array with `parent_reply_id`)
  - `total`, `page`, `limit`
- No `user_id`, `is_flagged`, or `updated_at` in returned reply objects.

## 3) Verify top-level reply creation
```bash
curl -X POST "http://localhost:3000/api/posts/<POST_ID_UUID>/replies" \
  -H "Authorization: Bearer <ACCESS_TOKEN>" \
  -H "Content-Type: application/json" \
  -d '{"content":"Top-level reply test"}'
```
Expected:
- `201 Created`
- `parent_reply_id: null`
- Includes `id, post_id, parent_reply_id, anonymous_name, content, language, created_at`

## 4) Verify nested reply creation
```bash
curl -X POST "http://localhost:3000/api/replies/<PARENT_REPLY_UUID>/replies" \
  -H "Authorization: Bearer <ACCESS_TOKEN>" \
  -H "Content-Type: application/json" \
  -d '{"content":"Nested reply test"}'
```
Expected:
- `201 Created`
- `parent_reply_id` equals `<PARENT_REPLY_UUID>`
- `post_id` matches root post id.

## 5) Verify one-level nesting guard
Try replying to a reply that is already nested.
Expected:
- `400 Bad Request`
- Message: `"Replies can only be nested one level deep."`

## 6) Verify validation + error handling
- Missing/empty content → `400`
- Content > 1000 chars → `400`
- Missing/invalid auth token → `401`
- Invalid/non-existent post or reply UUID target → `404`
- Unexpected server error path → `500` with generic client message

## 7) Verify content safety flagging
Create reply with email/phone-like text.
Expected:
- Reply is created
- Row is flagged internally (`is_flagged = true`)
- Moderation log entry is created in `moderation_logs`

## 8) Verify reply count increment
After successful top-level or nested insert, confirm `posts.reply_count` increments by 1 for the parent/root post.