### PR TITLE
(WIP)feat/docs: English <-> Tagalog Translation endpoint, validation, and logic using LibreTranslate

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -59,6 +59,7 @@
       "version": "7.29.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1714,6 +1715,7 @@
       "version": "19.2.14",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1758,6 +1760,7 @@
       "version": "8.15.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1847,6 +1850,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2067,6 +2071,7 @@
       "version": "9.39.2",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2930,6 +2935,7 @@
       "version": "4.0.4",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2978,6 +2984,7 @@
       "version": "3.8.3",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -3082,6 +3089,7 @@
     "node_modules/react": {
       "version": "19.2.5",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3089,6 +3097,7 @@
     "node_modules/react-dom": {
       "version": "19.2.5",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -3101,6 +3110,7 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.72.1.tgz",
       "integrity": "sha512-RhwBoy2ygeVZje+C+bwJ8g0NjTdBmDlJvAUHTxRjTmSUKPYsKfMphkS2sgEMotsY03bP358yEYlnUeZy//D9Ig==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -3401,6 +3411,7 @@
       "version": "7.3.2",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -3545,6 +3556,7 @@
       "version": "4.3.6",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/client/src/pages/PostDetail.jsx
+++ b/client/src/pages/PostDetail.jsx
@@ -11,7 +11,7 @@ import { Link, useParams } from "react-router-dom";
 import { AuthContext } from "../context/auth-context";
 import ReplyInput from "../components/ReplyInput";
 import ReplyThread from "../components/ReplyThread";
-import { fetchJson } from "../services/api";
+import { fetchJson, translatePost } from "../services/api";
 import { supabase } from "../services/supabaseClient";
 
 const REPLY_PAGE_SIZE = 100;
@@ -44,6 +44,20 @@ export default function PostDetail() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const [isReplyComposerOpen, setIsReplyComposerOpen] = useState(false);
+  const [translating, setTranslating] = useState(false);
+  // Handles translation of the post content
+  const handleTranslate = async () => {
+    if (!post || translating) return;
+    setTranslating(true);
+    try {
+      const userId = user?.id || user?.auth_user_id;
+      const result = await translatePost({ text: post.content, userId });
+      setPost((current) => current ? { ...current, content: result.translatedText || result.text || result } : current);
+    } catch (err) {
+    } finally {
+      setTranslating(false);
+    }
+  };
 
   useEffect(() => {
     let cancelled = false;
@@ -165,9 +179,15 @@ export default function PostDetail() {
             </div>
 
             <div className="mt-8 flex flex-wrap items-center gap-5 text-[#4C383A]">
-              <span className="inline-flex min-w-[150px] items-center justify-center rounded-[8px] bg-[#8C97BC] px-6 py-3 font-darumadropone text-[26px] leading-none text-[#4C383A] shadow-[0_8px_20px_rgba(140,151,188,0.35)]">
-                translate
-              </span>
+              <button
+                type="button"
+                onClick={handleTranslate}
+                className="inline-flex min-w-[150px] items-center justify-center rounded-[8px] bg-[#8C97BC] px-6 py-3 font-darumadropone text-[26px] leading-none text-[#4C383A] shadow-[0_8px_20px_rgba(140,151,188,0.35)] disabled:opacity-60"
+                disabled={translating}
+                aria-label="Translate post"
+              >
+                {translating ? "Translating..." : "translate"}
+              </button>
               <button
                 type="button"
                 onClick={() => setIsReplyComposerOpen((current) => !current)}

--- a/client/src/services/api.js
+++ b/client/src/services/api.js
@@ -21,3 +21,21 @@ export const fetchJson = async (path, options = {}) => {
 };
 
 export { API_BASE_URL };
+
+/**
+ * Translate post content to the user's main language using backend API.
+ * @param {Object} params - Parameters for translation.
+ * @param {string} params.text - The text to translate.
+ * @param {string} params.userId - The user's ID (for language preference).
+ * 
+ * @returns {Promise<string>} The translated text.
+ */
+export async function translatePost({ text, userId }) {
+  return fetchJson("/translate", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ text, userId }),
+  });
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -298,6 +298,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
       "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }

--- a/server/controllers/translateController.js
+++ b/server/controllers/translateController.js
@@ -9,9 +9,61 @@ const translate = async (req, res) => {
             return res.status(400).json({ error: 'Text is required' });
         }
 
-        // For minimal version, it uses a hardcoded target = English for the language
-        const target = 'en';
+        const authHeader = req.headers.authorization;
 
+        if (!authHeader) {
+            return res.status(401).json({ error: 'No auth token' });
+        }
+
+        const [scheme, token] = authHeader.split(' ');
+
+        if (scheme !== 'Bearer' || !token) {
+            return res.status(401).json({ error: 'Invalid authorization format' });
+        }
+
+        const { data: userData, error: authError } = await supabase.auth.getUser(token);
+
+        if (authError || !userData || !userData.user) {
+            return res.status(401).json({ error: 'Invalid token' });
+        }
+
+        const auth_user_id = userData.user.id;
+
+        const { data: profile, error: profileError } = await supabase
+            .from('users')
+            .select('language')
+            .eq('id', auth_user_id)
+            .single();
+
+        if (profileError || !profile) {
+            return res.status(400).json({ error: 'User profile not found' });
+        }
+
+        const target = profile.language;
+
+        if (!target) {
+            return res.status(400).json({ error: 'User preferred language not set' });
+        }
+
+        // Validate target against provider-supported languages
+        let supported = [];
+
+        try {
+            supported = await translationService.getSupportedLanguages();
+        } catch (err) {
+            console.error('Failed to fetch supported languages', err);
+        }
+
+        const isSupported = supported.some((l) => {
+            // LibreTranslate languages objects often have `code` and `name`.
+            return l.code === target || l.language === target || l.name === target;
+        });
+
+        if (supported.length > 0 && !isSupported) {
+            return res.status(400).json({ error: 'Target language not supported' });
+        }
+
+        // Detect source language if not provided
         let detected = source || null;
 
         try {
@@ -34,6 +86,7 @@ const translate = async (req, res) => {
 
         const data = await translationService.translateText(text, target, source || 'auto');
 
+        // normalize translated text
         const translated_text = data && (data.translatedText || data.translated_text || data.result || data.translation || null);
 
         if (!translated_text) {

--- a/server/controllers/translateController.js
+++ b/server/controllers/translateController.js
@@ -2,20 +2,24 @@
 const translationService = require('../services/translationService');
 const supabase = require('../supabaseClient');
 
-/**
- * Translate endpoint controller
- * Handles translation requests for authenticated users.
- * - Validates input and authentication
- * - Looks up user's preferred language from Supabase
- * - Checks if translation is needed (avoids same-language translation)
- * - Only allows English and Tagalog to be translated
- * - Calls LibreTranslate API for translation
- * - Returns translated or original text with metadata
- *
- * @param {Request} req Express request object
- * @param {Response} res Express response object
- */
+
 const translate = async (req, res) => {
+    /**
+     * Translate endpoint controller
+     * Handles translation requests for authenticated users.
+     * - Validates input and authentication
+     * - Looks up user's preferred language from Supabase
+     * - Checks if translation is needed (avoids same-language translation)
+     * - Only allows English and Tagalog to be translated
+     * - Calls LibreTranslate API for translation
+     * - Returns translated or original text with metadata
+     *
+     * @param {Request} req Express request object
+     * @param {Response} res Express response object
+     * 
+     * @returns {Promise<Response>} JSON response with translation result or error message
+     */
+
     try {
         const { text, source } = req.body || {};
         if (!text) return res.status(400).json({ error: 'Text is required for translation' });
@@ -47,7 +51,7 @@ const translate = async (req, res) => {
             return res.status(400).json({ error: 'Translation is only available for English and Tagalog. Please set your language to English or Tagalog in your profile.' });
         }
 
-        // Check if target language is supported
+        // Check if target language is supported by using getSupportedLanguages() from translationService
         let supported = [];
         try {
             supported = await translationService.getSupportedLanguages();
@@ -59,7 +63,7 @@ const translate = async (req, res) => {
             return res.status(400).json({ error: 'Target language not supported' });
         }
 
-        // Detect source language if not provided
+        // Detect source language if not provided by using dectLanguage() from translationService
         let detected = source || null;
         try {
             if (!detected) detected = await translationService.detectLanguage(text);
@@ -80,7 +84,7 @@ const translate = async (req, res) => {
             });
         }
 
-        // Translate the text(Main functionality)
+        // Translate the text(Main functionality) by calling the translationText() from translationService
         const data = await translationService.translateText(text, target, source || 'auto');
         const translated_text = data && (data.translatedText || data.translated_text || data.result || data.translation || null);
         if (!translated_text) {

--- a/server/controllers/translateController.js
+++ b/server/controllers/translateController.js
@@ -77,6 +77,12 @@ const translate = async (req, res) => {
             return res.status(400).json({ error: 'User preferred language is not set' });
         }
 
+        // Restrict supported languages to only English and Tagalog
+        const allowedLanguages = ['en', 'tl'];
+        if (!allowedLanguages.includes(target)) {
+            return res.status(400).json({ error: 'Only English and Tagalog are supported for translation.' });
+        }
+
         // Validate that the target language is supported by the translation provider
         let supported = [];
 

--- a/server/controllers/translateController.js
+++ b/server/controllers/translateController.js
@@ -1,80 +1,120 @@
 const translationService = require('../services/translationService');
 const supabase = require('../supabaseClient');
 
+
+/**
+ * Translate endpoint controller
+ * Handles translation requests for authenticated users.
+ * - Validates input and authentication
+ * - Looks up user's preferred language from Supabase
+ * - Checks if translation is needed (avoids same-language translation)
+ * - Calls LibreTranslate API for translation
+ * - Returns translated or original text with metadata
+ *
+ * @param {Request} req Express request object
+ * @param {Response} res Express response object
+ */
 const translate = async (req, res) => {
     try {
+        // Extract text to translate and optional source language from request body
         const { text, source } = req.body || {};
 
+        // Check if text is provided in the request
         if (!text) {
+            // If not, return a 400 Bad Request error
             return res.status(400).json({ error: 'Text is required' });
         }
 
+        // Get the Authorization header from the request
         const authHeader = req.headers.authorization;
 
+        // Check if the Authorization header is present
         if (!authHeader) {
+            // If not, return a 401 Unauthorized error
             return res.status(401).json({ error: 'No auth token' });
         }
 
+        // Split the Authorization header into scheme and token
         const [scheme, token] = authHeader.split(' ');
 
+        // Check if the scheme is 'Bearer' and token exists
         if (scheme !== 'Bearer' || !token) {
+            // If not, return a 401 Unauthorized error
             return res.status(401).json({ error: 'Invalid authorization format' });
         }
 
+        // Use Supabase to validate the user's token and get user data
         const { data: userData, error: authError } = await supabase.auth.getUser(token);
 
+        // Check if user is authenticated and user data is valid
         if (authError || !userData || !userData.user) {
+            // If not, return a 401 Unauthorized error
             return res.status(401).json({ error: 'Invalid token' });
         }
 
+        // Get the authenticated user's ID
         const auth_user_id = userData.user.id;
 
+        // Query Supabase for the user's profile and preferred language
         const { data: profile, error: profileError } = await supabase
             .from('users')
             .select('language')
             .eq('id', auth_user_id)
             .single();
 
+        // Check if the user's profile was found and contains a language
         if (profileError || !profile) {
+            // If not, return a 400 Bad Request error
             return res.status(400).json({ error: 'User profile not found' });
         }
 
+        // Get the user's preferred language
         const target = profile.language;
 
+        // Check if the preferred language is set
         if (!target) {
+            // If not, return a 400 Bad Request error
             return res.status(400).json({ error: 'User preferred language not set' });
         }
 
-        // Validate target against provider-supported languages
+        // Validate that the target language is supported by the translation provider
         let supported = [];
 
         try {
+            // Fetch supported languages from LibreTranslate
             supported = await translationService.getSupportedLanguages();
         } catch (err) {
+            // Log error but continue (may result in later error if unsupported)
             console.error('Failed to fetch supported languages', err);
         }
 
+        // Check if the user's preferred language is in the supported list
         const isSupported = supported.some((l) => {
             // LibreTranslate languages objects often have `code` and `name`.
             return l.code === target || l.language === target || l.name === target;
         });
 
         if (supported.length > 0 && !isSupported) {
+            // If not supported, return a 400 Bad Request error
             return res.status(400).json({ error: 'Target language not supported' });
         }
 
-        // Detect source language if not provided
+        // Detect the source language if not provided
         let detected = source || null;
 
         try {
+            // If source language is not provided, use LibreTranslate to detect it
             if (!detected) {
                 detected = await translationService.detectLanguage(text);
             }
         } catch (err) {
+            // If detection fails, log a warning and continue with 'auto'
             console.warn('Language detection failed, continuing with auto');
         }
 
+        // If the detected source language matches the target, skip translation
         if (detected && detected === target) {
+            // Return the original text and indicate no translation was needed
             return res.json({
                 original_text: text,
                 translated_text: text,
@@ -84,17 +124,22 @@ const translate = async (req, res) => {
             });
         }
 
+        // Call the translation service to translate the text
         const data = await translationService.translateText(text, target, source || 'auto');
 
-        // normalize translated text
+        // Normalize the translated text from the provider's response
         const translated_text = data && (data.translatedText || data.translated_text || data.result || data.translation || null);
 
+        // Check if translation was successful
         if (!translated_text) {
+            // If not, return a 502 Bad Gateway error
             return res.status(502).json({ error: 'Translation provider returned unexpected response' });
         }
 
+        // Return the translated text and metadata
         return res.json({ original_text: text, translated_text, source_language: detected, target_language: target });
     } catch (err) {
+        // Catch any unexpected errors and return a 500 Internal Server Error
         console.error(err);
         return res.status(500).json({ error: 'Server error' });
     }

--- a/server/controllers/translateController.js
+++ b/server/controllers/translateController.js
@@ -1,0 +1,50 @@
+const translationService = require('../services/translationService');
+const supabase = require('../supabaseClient');
+
+const translate = async (req, res) => {
+    try {
+        const { text, source } = req.body || {};
+
+        if (!text) {
+            return res.status(400).json({ error: 'Text is required' });
+        }
+
+        // For minimal version, it uses a hardcoded target = English for the language
+        const target = 'en';
+
+        let detected = source || null;
+
+        try {
+            if (!detected) {
+                detected = await translationService.detectLanguage(text);
+            }
+        } catch (err) {
+            console.warn('Language detection failed, continuing with auto');
+        }
+
+        if (detected && detected === target) {
+            return res.json({
+                original_text: text,
+                translated_text: text,
+                source_language: detected,
+                target_language: target,
+                no_op: true
+            });
+        }
+
+        const data = await translationService.translateText(text, target, source || 'auto');
+
+        const translated_text = data && (data.translatedText || data.translated_text || data.result || data.translation || null);
+
+        if (!translated_text) {
+            return res.status(502).json({ error: 'Translation provider returned unexpected response' });
+        }
+
+        return res.json({ original_text: text, translated_text, source_language: detected, target_language: target });
+    } catch (err) {
+        console.error(err);
+        return res.status(500).json({ error: 'Server error' });
+    }
+};
+
+module.exports = { translate };

--- a/server/controllers/translateController.js
+++ b/server/controllers/translateController.js
@@ -22,7 +22,7 @@ const translate = async (req, res) => {
         // Check if text is provided in the request
         if (!text) {
             // If not, return a 400 Bad Request error
-            return res.status(400).json({ error: 'Text is required' });
+            return res.status(400).json({ error: 'Text is required for translation' });
         }
 
         // Get the Authorization header from the request
@@ -74,7 +74,7 @@ const translate = async (req, res) => {
         // Check if the preferred language is set
         if (!target) {
             // If not, return a 400 Bad Request error
-            return res.status(400).json({ error: 'User preferred language not set' });
+            return res.status(400).json({ error: 'User preferred language is not set' });
         }
 
         // Validate that the target language is supported by the translation provider

--- a/server/controllers/translateController.js
+++ b/server/controllers/translateController.js
@@ -1,6 +1,6 @@
+
 const translationService = require('../services/translationService');
 const supabase = require('../supabaseClient');
-
 
 /**
  * Translate endpoint controller
@@ -8,6 +8,7 @@ const supabase = require('../supabaseClient');
  * - Validates input and authentication
  * - Looks up user's preferred language from Supabase
  * - Checks if translation is needed (avoids same-language translation)
+ * - Only allows English and Tagalog to be translated
  * - Calls LibreTranslate API for translation
  * - Returns translated or original text with metadata
  *
@@ -16,136 +17,83 @@ const supabase = require('../supabaseClient');
  */
 const translate = async (req, res) => {
     try {
-        // Extract text to translate and optional source language from request body
         const { text, source } = req.body || {};
+        if (!text) return res.status(400).json({ error: 'Text is required for translation' });
 
-        // Check if text is provided in the request
-        if (!text) {
-            // If not, return a 400 Bad Request error
-            return res.status(400).json({ error: 'Text is required for translation' });
-        }
-
-        // Get the Authorization header from the request
+        // Check that user is authenticated
         const authHeader = req.headers.authorization;
-
-        // Check if the Authorization header is present
-        if (!authHeader) {
-            // If not, return a 401 Unauthorized error
-            return res.status(401).json({ error: 'No auth token' });
-        }
-
-        // Split the Authorization header into scheme and token
+        if (!authHeader) return res.status(401).json({ error: 'No auth token' });
         const [scheme, token] = authHeader.split(' ');
+        if (scheme !== 'Bearer' || !token) return res.status(401).json({ error: 'Invalid authorization format' });
 
-        // Check if the scheme is 'Bearer' and token exists
-        if (scheme !== 'Bearer' || !token) {
-            // If not, return a 401 Unauthorized error
-            return res.status(401).json({ error: 'Invalid authorization format' });
-        }
-
-        // Use Supabase to validate the user's token and get user data
+        // Ensure user is logged into Supabase
         const { data: userData, error: authError } = await supabase.auth.getUser(token);
+        if (authError || !userData || !userData.user) return res.status(401).json({ error: 'Invalid token' });
+        const userId = userData.user.id;
 
-        // Check if user is authenticated and user data is valid
-        if (authError || !userData || !userData.user) {
-            // If not, return a 401 Unauthorized error
-            return res.status(401).json({ error: 'Invalid token' });
-        }
-
-        // Get the authenticated user's ID
-        const auth_user_id = userData.user.id;
-
-        // Query Supabase for the user's profile and preferred language
+        // Look up user's preferred language from Supabase
         const { data: profile, error: profileError } = await supabase
             .from('users')
             .select('language')
-            .eq('id', auth_user_id)
+            .eq('id', userId)
             .single();
-
-        // Check if the user's profile was found and contains a language
-        if (profileError || !profile) {
-            // If not, return a 400 Bad Request error
-            return res.status(400).json({ error: 'User profile not found' });
-        }
-
-        // Get the user's preferred language
+        if (profileError || !profile) return res.status(400).json({ error: 'User profile not found' });
         const target = profile.language;
+        if (!target) return res.status(400).json({ error: 'User preferred language is not set' });
 
-        // Check if the preferred language is set
-        if (!target) {
-            // If not, return a 400 Bad Request error
-            return res.status(400).json({ error: 'User preferred language is not set' });
-        }
-
-        // Restrict supported languages to only English and Tagalog
+        // Only allow English and Tagalog
         const allowedLanguages = ['en', 'tl'];
         if (!allowedLanguages.includes(target)) {
-            return res.status(400).json({ error: 'Only English and Tagalog are supported for translation.' });
+            return res.status(400).json({ error: 'Translation is only available for English and Tagalog. Please set your language to English or Tagalog in your profile.' });
         }
 
-        // Validate that the target language is supported by the translation provider
+        // Check if target language is supported
         let supported = [];
-
         try {
-            // Fetch supported languages from LibreTranslate
             supported = await translationService.getSupportedLanguages();
         } catch (err) {
-            // Log error but continue (may result in later error if unsupported)
             console.error('Failed to fetch supported languages', err);
         }
-
-        // Check if the user's preferred language is in the supported list
-        const isSupported = supported.some((l) => {
-            // LibreTranslate languages objects often have `code` and `name`.
-            return l.code === target || l.language === target || l.name === target;
-        });
-
+        const isSupported = supported.some(l => l.code === target || l.language === target || l.name === target);
         if (supported.length > 0 && !isSupported) {
-            // If not supported, return a 400 Bad Request error
             return res.status(400).json({ error: 'Target language not supported' });
         }
 
-        // Detect the source language if not provided
+        // Detect source language if not provided
         let detected = source || null;
-
         try {
-            // If source language is not provided, use LibreTranslate to detect it
-            if (!detected) {
-                detected = await translationService.detectLanguage(text);
-            }
+            if (!detected) detected = await translationService.detectLanguage(text);
         } catch (err) {
-            // If detection fails, log a warning and continue with 'auto'
             console.warn('Language detection failed, continuing with auto');
         }
-
-        // If the detected source language matches the target, skip translation
+        if (detected && !allowedLanguages.includes(detected)) {
+            return res.status(400).json({ error: 'Only English and Tagalog text can be translated at this time.' });
+        }
         if (detected && detected === target) {
-            // Return the original text and indicate no translation was needed
             return res.json({
                 original_text: text,
                 translated_text: text,
                 source_language: detected,
                 target_language: target,
-                no_op: true
+                no_op: true,
+                message: 'This post is already in your preferred language.'
             });
         }
 
-        // Call the translation service to translate the text
+        // Translate the text(Main functionality)
         const data = await translationService.translateText(text, target, source || 'auto');
-
-        // Normalize the translated text from the provider's response
         const translated_text = data && (data.translatedText || data.translated_text || data.result || data.translation || null);
-
-        // Check if translation was successful
         if (!translated_text) {
-            // If not, return a 502 Bad Gateway error
-            return res.status(502).json({ error: 'Translation provider returned unexpected response' });
+            return res.status(502).json({ error: 'Sorry, something went wrong with the translation service.' });
         }
-
-        // Return the translated text and metadata
-        return res.json({ original_text: text, translated_text, source_language: detected, target_language: target });
+        return res.json({
+            original_text: text,
+            translated_text,
+            source_language: detected,
+            target_language: target,
+            message: 'Translation successful.'
+        });
     } catch (err) {
-        // Catch any unexpected errors and return a 500 Internal Server Error
         console.error(err);
         return res.status(500).json({ error: 'Server error' });
     }

--- a/server/index.js
+++ b/server/index.js
@@ -6,6 +6,7 @@ const cors = require('cors');
 const promptRoutes = require('./routes/prompts');
 const postRoutes = require('./routes/posts');
 const reportRoutes = require('./routes/reports');
+const translateRoutes = require('./routes/translate');
 
 const app = express();
 const PORT = process.env.PORT || 3000;
@@ -17,6 +18,7 @@ app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 app.use('/api/posts', postRoutes);
 app.use('/api', reportRoutes);
+app.use('/api', translateRoutes);
 
 // Routes
 app.get('/', (req, res) => {

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -12,7 +12,9 @@
         "@supabase/supabase-js": "^2.103.0",
         "cors": "^2.8.6",
         "dotenv": "^17.4.2",
-        "express": "^5.2.1"
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.5.1",
+        "install": "^0.13.0"
       }
     },
     "node_modules/@supabase/auth-js": {
@@ -368,6 +370,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -404,6 +407,24 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.1.tgz",
+      "integrity": "sha512-5O6KYmyJEpuPJV5hNTXKbAHWRqrzyu+OI3vUnSd2kXFubIVpG7ezpgxQy76Zo5GQZtrQBg86hF+CM/NX+cioiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
       }
     },
     "node_modules/finalhandler": {
@@ -577,6 +598,24 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
+    },
+    "node_modules/install": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/install/-/install-0.13.0.tgz",
+      "integrity": "sha512-zDml/jzr2PKU9I8J/xyZBQn8rPCAY//UOYNmR01XwNwyfhEWObo2SWfSl1+0tm1u6PhxLwDnfsT/6jB7OUxqFA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",

--- a/server/package.json
+++ b/server/package.json
@@ -16,6 +16,8 @@
     "@supabase/supabase-js": "^2.103.0",
     "cors": "^2.8.6",
     "dotenv": "^17.4.2",
-    "express": "^5.2.1"
+    "express": "^5.2.1",
+    "express-rate-limit": "^8.5.1",
+    "install": "^0.13.0"
   }
 }

--- a/server/routes/translate.js
+++ b/server/routes/translate.js
@@ -2,7 +2,7 @@ const express = require('express');
 const router = express.Router();
 const { translate } = require('../controllers/translateController');
 
-// POST /api/translate
+// POST /api/translate: Calls the translate controller to handle language translation requests
 router.post('/translate', translate);
 
 module.exports = router;

--- a/server/routes/translate.js
+++ b/server/routes/translate.js
@@ -1,8 +1,24 @@
 const express = require('express');
+const rateLimit = require('express-rate-limit');
 const router = express.Router();
 const { translate } = require('../controllers/translateController');
 
-// POST /api/translate: Calls the translate controller to handle language translation requests
-router.post('/translate', translate);
+// Set up rate limiting for the translate endpoint
+const translateLimiter = rateLimit({
+  windowMs: 10 * 60 * 1000, // 10 minutes
+  max: 30 // limit each IP address to 30 requests per windowMs
+});
 
+/**
+ * Calls the translate controller to handle language translation requests.
+ *
+ * Route:
+ *   POST /api/translate
+ *
+ * Delegates to:
+ *   translateController.translate
+ *
+ * Example: POST http://localhost:3000/api/translate
+ */
+router.post('/translate', translateLimiter, translate);
 module.exports = router;

--- a/server/routes/translate.js
+++ b/server/routes/translate.js
@@ -1,0 +1,8 @@
+const express = require('express');
+const router = express.Router();
+const { translate } = require('../controllers/translateController');
+
+// POST /api/translate
+router.post('/translate', translate);
+
+module.exports = router;

--- a/server/services/translationService.js
+++ b/server/services/translationService.js
@@ -2,7 +2,18 @@ const LIBRE_URL = process.env.LIBRETRANSLATE_URL || 'https://libretranslate.com'
 const API_KEY = process.env.LIBRETRANSLATE_API_KEY || '';
 
 async function fetchJson(url, opts = {}) {
-
+  /**
+   * Performs an HTTP request to the given URL with the provided options,
+   * and returns the parsed JSON response. Throws an error if the response
+   * is not OK (status not in the 200-299 range).
+   */
+    const res = await fetch(url, opts);
+    if (!res.ok) {
+        // If the response is not successful, throw an error with status code, status text, and error text
+        const errorText = await res.text();
+        throw new Error(`Fetch failed: ${res.status} ${res.statusText} - ${errorText}`);
+    }
+    return res.json();
 }
 
 async function getSupportedLanguages() {

--- a/server/services/translationService.js
+++ b/server/services/translationService.js
@@ -6,7 +6,13 @@ async function fetchJson(url, opts = {}) {
      * Performs an HTTP request to the given URL with the provided options,
      * and returns the parsed JSON response. Throws an error if the response
      * is not OK (status not in the 200-299 range).
+     *
+     * @param {string} url - The URL to send the request to.
+     * @param {object} [opts={}] - Optional fetch options (method, headers, body, etc).
+     * 
+     * @returns {Promise<any>} - The parsed JSON response from the server.
      */
+
       const res = await fetch(url, opts);
       if (!res.ok) {
           // If the response is not successful, throw an error with status code, status text, and error text
@@ -28,6 +34,7 @@ async function getSupportedLanguages() {
      */
 
     const url = `${LIBRE_URL}/languages`;
+
     // If an API key is set, include it in the request body (LibreTranslate supports this for some endpoints)
     const opts = {
         method: 'GET',
@@ -38,12 +45,77 @@ async function getSupportedLanguages() {
     return await fetchJson(url, opts);
 }
 
-async function detectLanguage(text) {
 
+async function detectLanguage(text) {
+    /**
+     * Detects the language of the given text using the LibreTranslate API.
+     * Returns the detected language code (e.g., 'en', 'es', 'fr').
+     * Throws an error if the API call fails or detection is not possible.
+     *
+     * @param {string} text - The text whose language should be detected.
+     * 
+     * @returns {Promise<string|null>} - The detected language code, or null if not detected.
+     */
+    
+    const url = `${LIBRE_URL}/detect`;
+    const body = { q: text };
+
+    // Optionally include API key if set
+    if (API_KEY) {
+        body.api_key = API_KEY;
+    }
+    const opts = {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body)
+    };
+
+    // Call the LibreTranslate API to detect language
+    const result = await fetchJson(url, opts);
+
+    // LibreTranslate returns an array of detections [{language: 'xx', confidence: ...}]
+    if (Array.isArray(result) && result.length > 0) {
+        return result[0].language;
+    }
+
+    return null;
 }
 
-async function translateText(text, target, source = 'auto') {
 
+async function translateText(text, target, source = 'auto') {
+  /**
+   * Translates the given text from the source language to the target language using the LibreTranslate API.
+   * Returns the translation result object from the API, which typically includes the translated text.
+   * Throws an error if the API call fails.
+   *
+   * @param {string} text - The text to translate.
+   * @param {string} target - The target language code (e.g., 'en', 'es').
+   * @param {string} [source='auto'] - The source language code, or 'auto' to detect automatically.
+   * 
+   * @returns {Promise<Object>} - The translation result object from the API.
+   */
+
+    const url = `${LIBRE_URL}/translate`;
+    const body = {
+        q: text,
+        source: source,
+        target: target,
+        format: 'text'
+    };
+
+    // Optionally include API key if set
+    if (API_KEY) {
+        body.api_key = API_KEY;
+    }
+    
+    const opts = {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body)
+    };
+    
+    // Call the LibreTranslate API to translate the text using custom helper function
+    return await fetchJson(url, opts);
 }
 
 module.exports = { getSupportedLanguages, detectLanguage, translateText };

--- a/server/services/translationService.js
+++ b/server/services/translationService.js
@@ -1,0 +1,20 @@
+const LIBRE_URL = process.env.LIBRETRANSLATE_URL || 'https://libretranslate.com';
+const API_KEY = process.env.LIBRETRANSLATE_API_KEY || '';
+
+async function fetchJson(url, opts = {}) {
+
+}
+
+async function getSupportedLanguages() {
+
+}
+
+async function detectLanguage(text) {
+
+}
+
+async function translateText(text, target, source = 'auto') {
+
+}
+
+module.exports = { getSupportedLanguages, detectLanguage, translateText };

--- a/server/services/translationService.js
+++ b/server/services/translationService.js
@@ -2,22 +2,40 @@ const LIBRE_URL = process.env.LIBRETRANSLATE_URL || 'https://libretranslate.com'
 const API_KEY = process.env.LIBRETRANSLATE_API_KEY || '';
 
 async function fetchJson(url, opts = {}) {
-  /**
-   * Performs an HTTP request to the given URL with the provided options,
-   * and returns the parsed JSON response. Throws an error if the response
-   * is not OK (status not in the 200-299 range).
-   */
-    const res = await fetch(url, opts);
-    if (!res.ok) {
-        // If the response is not successful, throw an error with status code, status text, and error text
-        const errorText = await res.text();
-        throw new Error(`Fetch failed: ${res.status} ${res.statusText} - ${errorText}`);
-    }
-    return res.json();
+    /**
+     * Performs an HTTP request to the given URL with the provided options,
+     * and returns the parsed JSON response. Throws an error if the response
+     * is not OK (status not in the 200-299 range).
+     */
+      const res = await fetch(url, opts);
+      if (!res.ok) {
+          // If the response is not successful, throw an error with status code, status text, and error text
+          const errorText = await res.text();
+          throw new Error(`Fetch failed: ${res.status} ${res.statusText} - ${errorText}`);
+      }
+      
+      return res.json();
 }
 
-async function getSupportedLanguages() {
 
+async function getSupportedLanguages() {
+    /**
+     * Fetches the list of supported languages from the LibreTranslate API.
+     * Returns an array of language objects, each with a code and name.
+     * Throws an error if the API call fails.
+     *
+     * @returns {Promise<Array<{code: string, name: string}>>}
+     */
+
+    const url = `${LIBRE_URL}/languages`;
+    // If an API key is set, include it in the request body (LibreTranslate supports this for some endpoints)
+    const opts = {
+        method: 'GET',
+        headers: { 'Content-Type': 'application/json' }
+    };
+
+    // Fetch the supported languages from the LibreTranslate API using custom helper function
+    return await fetchJson(url, opts);
 }
 
 async function detectLanguage(text) {

--- a/server/services/translationService.js
+++ b/server/services/translationService.js
@@ -1,6 +1,7 @@
 const LIBRE_URL = process.env.LIBRETRANSLATE_URL || 'https://libretranslate.com';
 const API_KEY = process.env.LIBRETRANSLATE_API_KEY || '';
 
+
 async function fetchJson(url, opts = {}) {
     /**
      * Performs an HTTP request to the given URL with the provided options,
@@ -15,7 +16,6 @@ async function fetchJson(url, opts = {}) {
 
       const res = await fetch(url, opts);
       if (!res.ok) {
-          // If the response is not successful, throw an error with status code, status text, and error text
           const errorText = await res.text();
           throw new Error(`Fetch failed: ${res.status} ${res.statusText} - ${errorText}`);
       }


### PR DESCRIPTION
# Description
- Set up 1 post endpoint
- Create a controller with HTTP error handling, authentication verification, and input text validation
- Add documentation for all functions
- Code the core logic into the service file
  - getSupportedLanguages()
  - detectLanguage(text)
  - translateText(text, target, source = 'auto')
- Apply basic rate limiting to the translation endpoint(30 requests every 10 minutes)
  - This uses the express-rate-limit package

The post endpoint calls the function int he controller file. The controller file uses 3 functions in the service file. The service file calls Supabase, so it knows what text to translate. The service file also calls the LibreTranslate open source API to actually perform translation. This data is sent to the function in the controller file, which then gets sent to the endpoint and should be used to update the frontend's UI(the reply).

# Type of Change

- [x] New feature
- [ ] Bug fix
- [x] Refactor
- [ ] CI/CD update
- [ ] Test
- [ ] Other (please explain):

# How to Test Changes
1. Install root dependencies:
   ```bash
   npm install
   ```

2. Install client dependencies:
   ```bash
   cd client && npm install
   ```

3. Install server dependencies:
   ```bash
   cd server && npm install
   ```

This is assuming the backend feature gets integrated into the frontend. I.e. the button to translate a reply or comment is already built and properly calls this endpoint.

## English to Tagalog
- Set your preferred language to English
- Make a reply in Tagalog
- Click translate and see if it turns into English

## Tagalog to Tagalog
- Set your preferred language to Tagalog
- Make a reply in English
- Click translate and see if it turns into Tagalog