### PR TITLE
[Frontend] Connect Saved Posts UI to API

### DIFF
--- a/client/src/pages/PostDetail.jsx
+++ b/client/src/pages/PostDetail.jsx
@@ -15,6 +15,7 @@ import { fetchJson, translatePost } from "../services/api";
 import MediaAttachment from "../components/MediaAttachment";
 import { uploadMedia } from "../services/mediaService";
 import { supabase } from "../services/supabaseClient";
+import { savePost, unsavePost } from "../services/savedPostService";
 
 const REPLY_PAGE_SIZE = 100;
 
@@ -47,6 +48,9 @@ export default function PostDetail() {
   const [error, setError] = useState(null);
   const [isReplyComposerOpen, setIsReplyComposerOpen] = useState(false);
   const [translating, setTranslating] = useState(false);
+  const [isSaved, setIsSaved] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+
   // Handles translation of the post content
   const handleTranslate = async () => {
     if (!post || translating) return;
@@ -58,6 +62,26 @@ export default function PostDetail() {
     } catch (err) {
     } finally {
       setTranslating(false);
+    }
+  };
+
+  const handleSaveToggle = async () => {
+    if (!post || isSaving) return;
+    const previousSavedState = isSaved;
+    const nextSavedState = !isSaved;
+    setIsSaved(nextSavedState);
+    setIsSaving(true);
+    try {
+      if (nextSavedState) {
+        await savePost(post.id);
+      } else {
+        await unsavePost(post.id);
+      }
+    } catch (err) {
+      setIsSaved(previousSavedState);
+      alert("Failed to update saved post. Please try again.");
+    } finally {
+      setIsSaving(false);
     }
   };
 
@@ -219,9 +243,18 @@ export default function PostDetail() {
               <span className="text-[28px]">
                 <LuHeart />
               </span>
-              <span className="text-[28px]">
-                <LuBookmark />
-              </span>
+              <button
+                type="button"
+                onClick={handleSaveToggle}
+                disabled={isSaving}
+                className="border-0 bg-transparent p-0 text-[#4C383A] transition hover:text-[#2f2325] disabled:opacity-60"
+                aria-label={isSaved ? "Unsave post" : "Save post"}
+              >
+                <LuBookmark
+                  className="text-[28px]"
+                  fill={isSaved ? "currentColor" : "none"}
+                />
+              </button>
               <span className="text-[28px]">
                 <LuEllipsis />
               </span>

--- a/client/src/pages/SavedPosts.jsx
+++ b/client/src/pages/SavedPosts.jsx
@@ -2,14 +2,7 @@ import { useState, useEffect } from 'react';
 import { useNavigate, Link } from 'react-router-dom';
 import Navbar from '../components/Navbar';
 import Stars from '../components/Stars';
-import { mockPosts } from '../mocks/mockData';
-
-// Temporary mock function for fetching "Saved Posts"
-const fetchSavedPosts = async () => {
-  await new Promise((resolve) => setTimeout(resolve, 1000));
-  // Return a different subset to simulate saved posts
-  return mockPosts.slice(4, 8); 
-};
+import { getSavedPosts, unsavePost } from '../services/savedPostService';
 
 export default function SavedPosts() {
   const navigate = useNavigate();
@@ -21,9 +14,8 @@ export default function SavedPosts() {
     const loadPosts = async () => {
       try {
         setIsLoading(true);
-        // TODO: Replace with real API call when Justin finishes the backend
-        const saved = await fetchSavedPosts();
-        setPosts(saved);
+        const saved = await getSavedPosts();
+        setPosts(saved.savedPosts || saved.posts || saved);
       } catch (err) {
         setError("Failed to load your saved posts. Please try again.");
       } finally {
@@ -42,9 +34,7 @@ export default function SavedPosts() {
     setPosts(current => current.filter(p => p.id !== postId));
 
     try {
-      // TODO: Replace with real DELETE request when backend is ready
-      await new Promise(resolve => setTimeout(resolve, 500));
-      // throw new Error("Mock API Failure"); // uncomment to test rollback!
+      await unsavePost(postId);
     } catch (err) {
       // If the backend fails, put the post back and warn the user
       setPosts(previousPosts);

--- a/client/src/services/savedPostService.js
+++ b/client/src/services/savedPostService.js
@@ -1,0 +1,46 @@
+import { fetchJson } from "./api";
+import { supabase } from "./supabaseClient";
+
+async function getAuthHeaders() {
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+
+  const token = session?.access_token;
+
+  if (!token) {
+    throw new Error("User is not authenticated");
+  }
+
+  return {
+    "Content-Type": "application/json",
+    Authorization: `Bearer ${token}`,
+  };
+}
+
+export async function getSavedPosts() {
+  const headers = await getAuthHeaders();
+
+  return fetchJson("/api/profile/saved-posts", {
+    method: "GET",
+    headers,
+  });
+}
+
+export async function savePost(postId) {
+  const headers = await getAuthHeaders();
+
+  return fetchJson(`/api/posts/${postId}/save`, {
+    method: "POST",
+    headers,
+  });
+}
+
+export async function unsavePost(postId) {
+  const headers = await getAuthHeaders();
+
+  return fetchJson(`/api/posts/${postId}/save`, {
+    method: "DELETE",
+    headers,
+  });
+}


### PR DESCRIPTION
## Summary
- Added a saved posts service for authenticated save, unsave, and fetch requests.
- Replaced mock saved posts data with the real saved posts API.
- Connected the post detail bookmark icon to save/unsave functionality.
- Added UI updates for unsaving posts from the saved posts page.

## Files Changed / Added

### `client/src/services/savedPostService.js` — Added
- Created a dedicated frontend service for saved-post API requests.
- Added `getSavedPosts()` to fetch the authenticated user's saved posts.
- Added `savePost(postId)` to save a post from the post detail page.
- Added `unsavePost(postId)` to remove a post from the user's saved posts.
- Added Supabase session token handling so each request includes the user's bearer token.

### `client/src/pages/SavedPosts.jsx` — Changed
- Removed temporary mock saved-post data and mock fetch logic.
- Connected the page to the real `getSavedPosts()` API call.
- Updated the saved posts list to render backend data.
- Connected the `unsave` button to the real `unsavePost(postId)` API call.
- Kept the UI behavior so saved posts disappear immediately after clicking `unsave`.
- Preserved rollback behavior if the unsave request fails.

### `client/src/pages/PostDetail.jsx` — Changed
- Imported the saved-post service functions.
- Added local `isSaved` and `isSaving` state for bookmark behavior.
- Added `handleSaveToggle()` to save or unsave the current post through the backend.
- Converted the static bookmark icon into a clickable button.
- Updated the bookmark icon to visually fill when the post is saved.
- Added disabled/loading behavior to prevent duplicate save/unsave requests.

## Testing
- Verified saved posts page loads from the backend.
- Verified unsaving a post removes it from the saved posts page.
- Verified bookmarking a post saves it successfully.